### PR TITLE
chore: increase file size upload limit

### DIFF
--- a/apps/api/src/file/file.constants.ts
+++ b/apps/api/src/file/file.constants.ts
@@ -1,2 +1,2 @@
 export const REDIS_TTL = 59 * 60 * 1000;
-export const MAX_FILE_SIZE = 20 * 1024 * 1024;
+export const MAX_FILE_SIZE = 1024 * 1024 * 1024;


### PR DESCRIPTION
Increasing the limit of uploaded videos, as in real case videos will usually have more than 20MB