### PR TITLE
fix: improve confusing translation in confirmation modal

### DIFF
--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -13,7 +13,7 @@
       "goBack": "Wróć",
       "clearAll": "Wyczyść wszystko",
       "ignore": "Ignoruj",
-      "validate": "Waliduj"
+      "validate": "Popraw błędy"
     },
     "tooltip": {
       "soon": "Dostępne wkrótce"
@@ -560,7 +560,7 @@
           "quizLessonDescription": "Ten typ pozwala na tworzenie quizów w ramach kursu z różnymi rodzajami pytań.",
           "leaveContentHeader": "Czy na pewno chcesz opuścić ten edytor pytań?",
           "leaveContentBody": "Spowoduje to utratę niezapisanych postępów",
-          "leaveContentBodyValidate": "Jeśli chcesz zapisać formularz, musisz najpierw zatwierdzić formularz"
+          "leaveContentBodyValidate": "Aby zapisać zmiany, popraw błędy w formularzu."
         }
       }
     },


### PR DESCRIPTION
After encountering the confirmation modal for the first time I had no idea what any of those buttons do :)

### Before:
![image](https://github.com/user-attachments/assets/47637bd9-8a2e-4212-a14f-833b81095f63)
### After:
![image](https://github.com/user-attachments/assets/52760c41-2666-4bde-9c26-7ee9f03dc681)
