### PR TITLE
refactor(SCS-486): clean up student and content creator profile according to design

### DIFF
--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -181,6 +181,7 @@
       "dashboard": "Dashboard"
     },
     "other": {
+      "pageTitle": "Profile",
       "about": "About",
       "contact": "Contact",
       "courses": "Courses",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -181,6 +181,7 @@
       "dashboard": "Panel"
     },
     "other": {
+      "pageTitle": "Profil",
       "about": "O",
       "contact": "Kontakt",
       "courses": "Kursy",

--- a/apps/web/app/modules/Profile/Profile.page.tsx
+++ b/apps/web/app/modules/Profile/Profile.page.tsx
@@ -20,14 +20,14 @@ export default function ProfilePage() {
   const { data: contentCreatorCourses } = useContentCreatorCourses(id, undefined, hasPermission);
   const { t } = useTranslation();
 
+  if (error) return <Navigate to="/" />;
+
   if (!userDetails)
     return (
       <div className="grid h-full w-full place-items-center">
         <Loader />
       </div>
     );
-
-  if (error) return <Navigate to="/" />;
 
   return (
     <PageWrapper role="main">

--- a/apps/web/app/modules/Profile/Profile.page.tsx
+++ b/apps/web/app/modules/Profile/Profile.page.tsx
@@ -27,7 +27,7 @@ export default function ProfilePage() {
       </div>
     );
 
-  if (error) return <Navigate to={"/"} />;
+  if (error) return <Navigate to="/" />;
 
   return (
     <PageWrapper role="main">

--- a/apps/web/app/modules/Profile/Profile.page.tsx
+++ b/apps/web/app/modules/Profile/Profile.page.tsx
@@ -3,15 +3,14 @@ import { useTranslation } from "react-i18next";
 
 import { useContentCreatorCourses } from "~/api/queries/useContentCreatorCourses";
 import { useUserDetails } from "~/api/queries/useUserDetails";
-import { ButtonGroup } from "~/components/ButtonGroup/ButtonGroup";
-import { Gravatar } from "~/components/Gravatar";
-import { Icon } from "~/components/Icon";
 import { PageWrapper } from "~/components/PageWrapper";
-import { Avatar } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
-import CourseCard from "~/modules/Dashboard/Courses/CourseCard";
 import { isAdminLike } from "~/utils/userRoles";
 
+import Loader from "../common/Loader/Loader";
+import { CoursesCarousel } from "../Dashboard/Courses/CoursesCarousel";
+
+import { ProfileCard } from "./components";
 import { ProfilePageBreadcrumbs } from "./ProfilePageBreadcrumbs";
 
 export default function ProfilePage() {
@@ -21,6 +20,13 @@ export default function ProfilePage() {
   const { data: contentCreatorCourses } = useContentCreatorCourses(id, undefined, hasPermission);
   const { t } = useTranslation();
 
+  if (!userDetails)
+    return (
+      <div className="grid h-full w-full place-items-center">
+        <Loader />
+      </div>
+    );
+
   if (error) return <Navigate to={"/"} />;
 
   return (
@@ -29,87 +35,20 @@ export default function ProfilePage() {
         id={id}
         username={`${userDetails?.firstName} ${userDetails?.lastName}`}
       />
-      <div className="flex flex-col gap-6 xl:flex-row">
-        <section className="flex flex-col gap-y-6 rounded-b-lg rounded-t-2xl bg-white p-6 drop-shadow xl:w-full xl:max-w-[480px]">
-          <div className="flex flex-col gap-6 md:flex-row md:items-center">
-            <Avatar className="size-20">
-              <Gravatar email={userDetails?.contactEmail || ""} />
-            </Avatar>
-            <div className="flex flex-col">
-              <h2 className="h6 text-neutral-950">{`${userDetails?.firstName} ${userDetails?.lastName}`}</h2>
-              <div className="flex flex-col gap-y-1">
-                {hasPermission && (
-                  <p className="body-sm">
-                    <span className="text-neutral-900">{t("contentCreatorView.other.title")}</span>{" "}
-                    <span className="font-medium text-neutral-950">{userDetails?.jobTitle}</span>
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-          {hasPermission && (
-            <div className="flex flex-col gap-y-2">
-              <div className="flex items-center gap-x-3">
-                <span className="text-neutral-900">{t("contentCreatorView.other.about")}</span>
-                <div className="h-px w-full bg-primary-200" />
-              </div>
-              <p className="body-base mt-2 text-neutral-950">{userDetails?.description}</p>
-            </div>
-          )}
-          {hasPermission && (
-            <div className="flex flex-col gap-y-1 md:gap-y-4 xl:mt-auto">
-              <div className="flex items-center gap-x-3">
-                <span className="text-neutral-900">{t("contentCreatorView.other.contact")}</span>
-                <div className="h-px w-full bg-primary-200" />
-              </div>
-              <div className="flex flex-col gap-3 md:flex-row md:*:w-full">
-                <a
-                  href={`tel:${userDetails?.contactPhone}`}
-                  className="body-base-md inline-flex gap-x-2 rounded-lg bg-primary-50 px-3 py-2 text-primary-700"
-                >
-                  <Icon name="Phone" className="size-6 text-neutral-900" />
-                  <span>{userDetails?.contactPhone}</span>
-                </a>
-                <a
-                  href={`mailto:${userDetails?.contactEmail}`}
-                  className="body-base-md inline-flex gap-x-2 rounded-lg bg-primary-50 px-3 py-2 text-primary-700"
-                >
-                  <Icon name="Email" className="size-6 text-neutral-900" />
-                  <span>{userDetails?.contactEmail}</span>
-                </a>
-              </div>
-            </div>
-          )}
-          {hasPermission && (
-            <Button variant="outline" className="sr-only">
-              {t("contentCreatorView.button.collapse")}
-            </Button>
-          )}
+      <div className="flex flex-col items-center gap-6">
+        <section className="flex w-full max-w-[720px] justify-between">
+          <h2 className="h5 md:h3 text-neutral-950">{t("contentCreatorView.other.pageTitle")}</h2>
         </section>
+        <ProfileCard isAdminLike={hasPermission} userDetails={userDetails} />
         {hasPermission && (
-          <section className="flex flex-col gap-y-6 rounded-b-lg rounded-t-2xl bg-white p-6 drop-shadow">
+          <section className="flex w-full max-w-[720px] flex-col gap-y-6 rounded-b-lg rounded-t-2xl bg-white p-6 drop-shadow">
             <div className="flex flex-col gap-y-2">
-              <h2 className="h5">{t("contentCreatorView.other.courses")}</h2>
-              <ButtonGroup
-                className="flex !w-full !max-w-none *:w-full md:!w-min"
-                buttons={[
-                  {
-                    children: "Courses",
-                    isActive: true,
-                  },
-                  {
-                    children: "Reviews",
-                    isActive: false,
-                    onClick: (e) => e.preventDefault(),
-                  },
-                ]}
-              />
-              {/*TODO: Add filters*/}
+              <h2 className="h5 md:h3">{t("contentCreatorView.other.courses")}</h2>
             </div>
-
-            <div className="flex flex-wrap gap-6 *:max-w-[250px] lg:max-h-[calc(100dvh-260px)] lg:overflow-y-scroll xl:gap-4">
-              {contentCreatorCourses?.map((course) => <CourseCard key={course.id} {...course} />)}
-            </div>
+            <CoursesCarousel
+              courses={contentCreatorCourses}
+              buttonContainerClasses="right-0 lg:-top-16"
+            />
             <Button variant="outline" className="sr-only">
               {t("contentCreatorView.button.showMore")}
             </Button>

--- a/apps/web/app/modules/Profile/components/ProfileCard.tsx
+++ b/apps/web/app/modules/Profile/components/ProfileCard.tsx
@@ -18,7 +18,7 @@ export const ProfileCard = ({ isAdminLike, userDetails }: ProfileCardProps) => {
   return (
     <section className="flex w-full max-w-[720px] flex-col gap-y-6 rounded-b-lg rounded-t-2xl bg-white p-6 drop-shadow">
       <div className="flex flex-col gap-6 md:flex-row md:items-center">
-        <Avatar className="h-32 w-32">
+        <Avatar className="size-32">
           <Gravatar email={userDetails?.contactEmail || ""} />
         </Avatar>
         <div className="flex w-full flex-col gap-4">
@@ -39,14 +39,14 @@ export const ProfileCard = ({ isAdminLike, userDetails }: ProfileCardProps) => {
                 href={`tel:${userDetails?.contactPhone}`}
                 className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-3 py-2 text-primary-700 md:justify-start"
               >
-                <Icon name="Phone" className="h-5 w-5 text-neutral-900" />
+                <Icon name="Phone" className="size-5 text-neutral-900" />
                 <span>{userDetails?.contactPhone}</span>
               </a>
               <a
                 href={`mailto:${userDetails?.contactEmail}`}
                 className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-2 py-1 text-primary-700 md:justify-start"
               >
-                <Icon name="Email" className="h-5 w-5 text-neutral-900" />
+                <Icon name="Email" className="size-5 text-neutral-900" />
                 <span>{userDetails?.contactEmail}</span>
               </a>
             </div>

--- a/apps/web/app/modules/Profile/components/ProfileCard.tsx
+++ b/apps/web/app/modules/Profile/components/ProfileCard.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from "react-i18next";
+
+import { Gravatar } from "~/components/Gravatar";
+import { Icon } from "~/components/Icon";
+import { Avatar } from "~/components/ui/avatar";
+import { Button } from "~/components/ui/button";
+
+import type { GetUserDetailsResponse } from "~/api/generated-api";
+
+type ProfileCardProps = {
+  isAdminLike: boolean;
+  userDetails?: GetUserDetailsResponse["data"];
+};
+
+export const ProfileCard = ({ isAdminLike, userDetails }: ProfileCardProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <section className="flex w-full max-w-[720px] flex-col gap-y-6 rounded-b-lg rounded-t-2xl bg-white p-6 drop-shadow">
+      <div className="flex flex-col gap-6 md:flex-row md:items-center">
+        <Avatar className="h-32 w-32">
+          <Gravatar email={userDetails?.contactEmail || ""} />
+        </Avatar>
+        <div className="flex w-full flex-col gap-4">
+          <div className="flex flex-col gap-y-2">
+            <h2 className="h6 md:h4 text-neutral-950">
+              {userDetails?.firstName} {userDetails?.lastName}
+            </h2>
+            {isAdminLike && (
+              <div className="body-sm">
+                <span className="text-neutral-900">{t("contentCreatorView.other.title")}:</span>{" "}
+                <span className="font-medium text-neutral-950">{userDetails?.jobTitle}</span>
+              </div>
+            )}
+          </div>
+          {isAdminLike && (
+            <div className="flex w-full flex-col gap-3 *:w-full md:flex-row md:*:w-fit">
+              <a
+                href={`tel:${userDetails?.contactPhone}`}
+                className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-3 py-2 text-primary-700 md:justify-start"
+              >
+                <Icon name="Phone" className="h-5 w-5 text-neutral-900" />
+                <span>{userDetails?.contactPhone}</span>
+              </a>
+              <a
+                href={`mailto:${userDetails?.contactEmail}`}
+                className="body-sm-md md:body-base-md flex items-center justify-center gap-x-2 rounded-lg bg-primary-50 px-2 py-1 text-primary-700 md:justify-start"
+              >
+                <Icon name="Email" className="h-5 w-5 text-neutral-900" />
+                <span>{userDetails?.contactEmail}</span>
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+      {isAdminLike && (
+        <div className="flex flex-col gap-y-2">
+          <div className="flex items-center gap-x-3">
+            <span className="min-w-fit text-neutral-900">
+              {t("contentCreatorView.other.about")}
+            </span>
+            <div className="h-px w-full bg-primary-200" />
+          </div>
+          <p className="body-base mt-2 text-neutral-950">{userDetails?.description}</p>
+        </div>
+      )}
+      <Button variant="outline" className="sr-only">
+        {t("contentCreatorView.button.collapse")}
+      </Button>
+    </section>
+  );
+};

--- a/apps/web/app/modules/Profile/components/index.ts
+++ b/apps/web/app/modules/Profile/components/index.ts
@@ -1,0 +1,3 @@
+import { ProfileCard } from "./ProfileCard";
+
+export { ProfileCard };

--- a/apps/web/app/modules/Profile/components/index.ts
+++ b/apps/web/app/modules/Profile/components/index.ts
@@ -1,3 +1,1 @@
-import { ProfileCard } from "./ProfileCard";
-
-export { ProfileCard };
+export { ProfileCard } from "./ProfileCard";


### PR DESCRIPTION
## Issue
[SCS-486](https://github.com/Selleo/mentingo/issues/486)

## Overview
Cleaned up profiles for admin, content creator and students to match the Figma design. The profiles work fully responsive.

## Screenshots

### Student profile before
![student-profile-before](https://github.com/user-attachments/assets/e7fca8b3-c841-47b8-ade8-421a6543af9f)

### Student profile after
![student-profile-after](https://github.com/user-attachments/assets/33c418f8-6e25-45a3-b7b9-2bfffcdcaa62)

### Admin/Content creator profile before
![admin-like-profile-before](https://github.com/user-attachments/assets/5792dca3-234b-46da-be59-2af8c7e0470c)

### Admin/Content creator profile after
![admin-like-profile-after](https://github.com/user-attachments/assets/bfc49241-4058-4917-a5d7-c424ce2eb6b1)
