### PR TITLE
fix(SCS-500): Add roles and verifications to course editing

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -10,7 +10,7 @@ module.exports = {
   bracketSameLine: false,
   arrowParens: "always",
   quoteProps: "as-needed",
-  endOfLine: "lf",
+  endOfLine: "auto",
   overrides: [
     {
       files: ["apps/web/**/*.{ts,tsx,js,jsx}"],

--- a/apps/api/src/courses/course.controller.ts
+++ b/apps/api/src/courses/course.controller.ts
@@ -235,8 +235,14 @@ export class CourseController {
     request: [{ type: "query", name: "id", schema: UUIDSchema, required: true }],
     response: baseResponse(commonShowBetaCourseSchema),
   })
-  async getBetaCourseById(@Query("id") id: UUIDType): Promise<BaseResponse<CommonShowBetaCourse>> {
-    return new BaseResponse(await this.courseService.getBetaCourseById(id));
+  async getBetaCourseById(
+    @Query("id") id: UUIDType,
+    @CurrentUser("userId") currentUserId: UUIDType,
+    @CurrentUser("role") currentUserRole: UserRole,
+  ): Promise<BaseResponse<CommonShowBetaCourse>> {
+    return new BaseResponse(
+      await this.courseService.getBetaCourseById(id, currentUserId, currentUserRole),
+    );
   }
 
   @Post()
@@ -269,8 +275,15 @@ export class CourseController {
     @Body() updateCourseBody: UpdateCourseBody,
     @UploadedFile() image: Express.Multer.File,
     @CurrentUser("userId") currentUserId: UUIDType,
+    @CurrentUser("role") currentUserRole: UserRole,
   ): Promise<BaseResponse<{ message: string }>> {
-    await this.courseService.updateCourse(id, updateCourseBody, image, currentUserId);
+    await this.courseService.updateCourse(
+      id,
+      updateCourseBody,
+      currentUserId,
+      currentUserRole,
+      image,
+    );
 
     return new BaseResponse({ message: "Pomyślnie zaktualizowano kurs" });
   }

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useSearchParams } from "@remix-run/react";
+import { Link, useParams, useSearchParams, Navigate } from "@remix-run/react";
 import { useTranslation } from "react-i18next";
 
 import { useBetaCourseById } from "~/api/queries/admin/useBetaCourse";
@@ -26,7 +26,8 @@ const EditCourse = () => {
   const courseTabs = useEditCourseTabs();
 
   if (!id) throw new Error("Course ID not found");
-  const { data: course, isLoading, dataUpdatedAt } = useBetaCourseById(id);
+  const { data: course, isLoading, dataUpdatedAt, error } = useBetaCourseById(id);
+
   const { previousDataUpdatedAt, currentDataUpdatedAt } = useTrackDataUpdatedAt(dataUpdatedAt);
   const handleTabChange = (tabValue: string) => {
     params.set("tab", tabValue);
@@ -43,6 +44,8 @@ const EditCourse = () => {
       </div>
     );
   }
+
+  if (error) return <Navigate to={"/"} />;
 
   const breadcrumbs = [
     { title: t("adminCourseView.breadcrumbs.myCourses"), href: "/admin/courses" },


### PR DESCRIPTION
## Jira issue(s)
[LC-500](https://github.com/Selleo/mentingo/issues/500)

## Overview
Admin now can edit all courses. Content_creator cannot open edit mode and edit courses of others. Changed "ls" to "auto" in prettier



[LC-500]: https://selleolabs.atlassian.net/browse/LC-500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ