### PR TITLE
fix(SCS-554): Update password creation button text and remove error display  

### DIFF
--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -166,7 +166,7 @@
     },
 
     "button": {
-      "changePassword": "Change password"
+      "changePassword": "Create password"
     }
   },
   "changePasswordView": {

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -166,7 +166,7 @@
       "passwordsDontMatch": "Hasła się nie zgadzają"
     },
     "button": {
-      "changePassword": "Zmień hasło"
+      "changePassword": "Utwórz hasło"
     }
   },
   "passwordValidationDisplay": {

--- a/apps/web/app/modules/Auth/CreateNewPassword.page.tsx
+++ b/apps/web/app/modules/Auth/CreateNewPassword.page.tsx
@@ -97,10 +97,6 @@ export default function CreateNewPasswordPage() {
                 className={cn({ "border-red-500": errors.newPassword })}
                 {...register("newPassword")}
               />
-
-              {errors.newPassword && (
-                <div className="text-sm text-red-500">{errors.newPassword.message}</div>
-              )}
             </div>
 
             <div className="grid gap-2">


### PR DESCRIPTION
## Jira issue(s)
[LC-554](https://github.com/Selleo/mentingo/issues/554)

## Overview
Update password creation button text and remove error display
## Screenshots

<img width="1652" height="1374" alt="image" src="https://github.com/user-attachments/assets/7b30a125-6a94-45cd-85cb-4e2b39a045cb" />
<img width="2360" height="1376" alt="image" src="https://github.com/user-attachments/assets/f1eeaf65-7f34-47a2-a7b9-c3b71261382a" />




