### PR TITLE
fix(SCS-597): fix query invalidation after updating freemium status

### DIFF
--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/components/ChaptersList.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/components/ChaptersList.tsx
@@ -144,6 +144,7 @@ const ChapterCard = ({
         console.error("Failed to update chapter premium status:", error);
       } finally {
         await queryClient.invalidateQueries({ queryKey: [COURSE_QUERY_KEY, { id: courseId }] });
+        await queryClient.invalidateQueries({ queryKey: ["available-courses"] });
         setTimeout(() => {
           setOpenItem(currentOpenState);
         }, 0);


### PR DESCRIPTION
## Jira issue(s)
[SCS-597](https://github.com/Selleo/mentingo/issues/597)

## Overview
Added a query invalidation for updating freemium status, so now it correctly displays without the need of refresh
