### PR TITLE
fix(678): Fixed redirect on course edit mode

### DIFF
--- a/apps/api/src/auth/token.service.ts
+++ b/apps/api/src/auth/token.service.ts
@@ -60,6 +60,6 @@ export class TokenService {
 
   clearTokenCookies(response: Response) {
     response.clearCookie("access_token");
-    response.clearCookie("refresh_token");
+    response.clearCookie("refresh_token", { path: "/api/auth/refresh" });
   }
 }

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useSearchParams, Navigate } from "@remix-run/react";
+import { Link, useParams, useSearchParams } from "@remix-run/react";
 import { useTranslation } from "react-i18next";
 
 import { useBetaCourseById } from "~/api/queries/admin/useBetaCourse";
@@ -29,7 +29,7 @@ const EditCourse = () => {
   const courseTabs = useEditCourseTabs();
 
   if (!id) throw new Error("Course ID not found");
-  const { data: course, isLoading, dataUpdatedAt, error } = useBetaCourseById(id);
+  const { data: course, isLoading, dataUpdatedAt } = useBetaCourseById(id);
 
   const { previousDataUpdatedAt, currentDataUpdatedAt } = useTrackDataUpdatedAt(dataUpdatedAt);
   const handleTabChange = (tabValue: string) => {
@@ -47,8 +47,6 @@ const EditCourse = () => {
       </div>
     );
   }
-
-  if (error) return <Navigate to="/" />;
 
   const breadcrumbs = [
     { title: t("adminCourseView.breadcrumbs.myCourses"), href: "/admin/courses" },


### PR DESCRIPTION
## Jira issue(s)
[678](https://github.com/Selleo/mentingo/issues/678)

## Overview
- Removed redirect on error in EditCourse, because randomly the first request for course returned 401, and then normally 200. 
- The video shows the cause of logout on tokens and how the error looks like after logout. And then I compared how it works when there is a redirect on error, and when it's removed

## Screenshots
https://github.com/user-attachments/assets/6de81f08-1e4a-4417-af83-b716b067e084

## Notes
The root issue is most likely located in token handling and logout. It seems that after logout, refresh token regenerates an access token, so you don't always get logged out correctly. And the tokens get glitched. Will be solved in another issue.
