### PR TITLE
fix(683): Made logout not regenerate tokens

### DIFF
--- a/apps/api/src/auth/token.service.ts
+++ b/apps/api/src/auth/token.service.ts
@@ -60,6 +60,6 @@ export class TokenService {
 
   clearTokenCookies(response: Response) {
     response.clearCookie("access_token");
-    response.clearCookie("refresh_token");
+    response.clearCookie("refresh_token", { path: "/api/auth/refresh" });
   }
 }


### PR DESCRIPTION
## Jira issue(s)
[683](https://github.com/Selleo/mentingo/issues/683)

## Overview
- Added path to cookie deletion for refresh token, as it was incorrectly deleted previously.

## Screenshots
https://github.com/user-attachments/assets/9d7ce5f2-491c-4a3d-a0a2-0d169f663640

