### PR TITLE
fix: add checks if category already exists and return a meaningful error

### DIFF
--- a/apps/api/src/category/category.service.ts
+++ b/apps/api/src/category/category.service.ts
@@ -1,4 +1,5 @@
 import {
+  ConflictException,
   Inject,
   Injectable,
   NotFoundException,
@@ -90,6 +91,14 @@ export class CategoryService {
   }
 
   public async createCategory(createCategoryBody: CategoryInsert) {
+    const category = await this.db.query.categories.findFirst({
+      where: ({ title }) => eq(title, createCategoryBody.title),
+    });
+
+    if (category) {
+      throw new ConflictException("Category already exists");
+    }
+
     const [newCategory] = await this.db.insert(categories).values(createCategoryBody).returning();
 
     if (!newCategory) throw new UnprocessableEntityException("Category not created");


### PR DESCRIPTION
<!--
 1. Make sure you have correct branch name i.e. `ab_PROJ-123_task_name`, where `LC-123` is a Jira issue ID, and `ab` is an author
 2. Make sure you have meaningful title related to task with correct prefix: feat/fix/chore/style/docs/refactor
 3. Reference multiple Jira issues in one PR by listing them in the Jira issue section
 4. Make sure all necessary sections are filled, remove obsolete sections
 5. Do a self review first
 6. Check if your PR includes only code related to your task
 7. `Notes` is used for additional info but also to notify if any action is required
-->

## Jira issue(s)
[#728](https://github.com/orgs/Selleo/projects/31/views/1?pane=issue&itemId=131999559&issue=Selleo%7Cmentingo%7C728)

## Overview

- Add checks if category already exists and return a meaningful error in `POST /api/category` entrypoint

## Screenshots

<img width="1634" height="791" alt="image" src="https://github.com/user-attachments/assets/1e68e9b4-b8a4-45fd-a491-5cd75954403c" />

<!-- ## Testing prerequisites

## Testing scenarios

- [ ] A
- [ ] B
- [ ] C 
-->