### PR TITLE
feat: login background upload

### DIFF
--- a/apps/api/src/common/types.ts
+++ b/apps/api/src/common/types.ts
@@ -11,6 +11,7 @@ export type GlobalSettings = {
   companyInformation?: CompanyInformationSchema;
   platformLogoS3Key: string | null;
   primaryColor: string | null;
+  loginBackgroundImageS3Key: string | null;
 };
 
 export type StudentSettings = {

--- a/apps/api/src/settings/__tests__/settings.login-background.controller.e2e-spec.ts
+++ b/apps/api/src/settings/__tests__/settings.login-background.controller.e2e-spec.ts
@@ -1,0 +1,101 @@
+import request from "supertest";
+
+import { createE2ETest } from "../../../test/create-e2e-test";
+import { createSettingsFactory } from "../../../test/factory/settings.factory";
+import { createUserFactory, type UserWithCredentials } from "../../../test/factory/user.factory";
+import { truncateTables, cookieFor } from "../../../test/helpers/test-helpers";
+
+import type { DatabasePg } from "../../common";
+import type { INestApplication } from "@nestjs/common";
+
+describe("SettingsController - login background (e2e)", () => {
+  let app: INestApplication;
+  let db: DatabasePg;
+  let userFactory: ReturnType<typeof createUserFactory>;
+  let globalSettingsFactory: ReturnType<typeof createSettingsFactory>;
+  const testPassword = "Password123@@";
+
+  beforeAll(async () => {
+    const { app: testApp } = await createE2ETest();
+    app = testApp;
+    db = app.get("DB");
+    userFactory = createUserFactory(db);
+    globalSettingsFactory = createSettingsFactory(db, null);
+  }, 20000);
+
+  afterAll(async () => {
+    await app.close();
+  }, 10000);
+
+  describe("GET /api/settings/login-background", () => {
+    beforeEach(async () => {
+      await truncateTables(db, ["settings"]);
+      await globalSettingsFactory.create({ userId: null });
+    });
+
+    it("should return public login background url (null by default)", async () => {
+      const response = await request(app.getHttpServer())
+        .get("/api/settings/login-background")
+        .expect(200);
+
+      expect(response.body).toBeDefined();
+      expect(response.body.data).toEqual({ url: null });
+    });
+  });
+
+  describe("PATCH /api/settings/login-background", () => {
+    let adminUser: UserWithCredentials;
+    let adminCookies: string[] | string;
+
+    beforeEach(async () => {
+      await truncateTables(db, ["settings"]);
+      await globalSettingsFactory.create({ userId: null });
+
+      adminUser = await userFactory
+        .withCredentials({ password: testPassword })
+        .withAdminSettings(db)
+        .create();
+
+      const loginResponse = await request(app.getHttpServer()).post("/api/auth/login").send({
+        email: adminUser.email,
+        password: adminUser.credentials?.password,
+      });
+      adminCookies = loginResponse.headers["set-cookie"];
+    });
+
+    it("should reject non-admins with 403", async () => {
+      const nonAdminUser = await userFactory
+        .withCredentials({ password: testPassword })
+        .withUserSettings(db)
+        .create();
+      const cookies = await cookieFor(nonAdminUser, app);
+
+      await request(app.getHttpServer())
+        .patch("/api/settings/login-background")
+        .set("Cookie", cookies)
+        .attach("login-background", Buffer.from("test"), {
+          filename: "bg.png",
+          contentType: "image/png",
+        })
+        .expect(403);
+    });
+
+    it("should allow admins to upload login background and then GET should return url", async () => {
+      await request(app.getHttpServer())
+        .patch("/api/settings/login-background")
+        .set("Cookie", Array.isArray(adminCookies) ? adminCookies : [adminCookies])
+        .attach("login-background", Buffer.from("test"), {
+          filename: "bg.png",
+          contentType: "image/png",
+        })
+        .expect(200);
+
+      const getResponse = await request(app.getHttpServer())
+        .get("/api/settings/login-background")
+        .expect(200);
+
+      expect(getResponse.body).toBeDefined();
+      expect(getResponse.body.data).toHaveProperty("url");
+    });
+  });
+});

--- a/apps/api/src/settings/__tests__/settings.login-background.service.spec.ts
+++ b/apps/api/src/settings/__tests__/settings.login-background.service.spec.ts
@@ -1,0 +1,49 @@
+import { createUnitTest, type TestContext } from "test/create-unit-test";
+import { createSettingsFactory } from "test/factory/settings.factory";
+import { truncateTables } from "test/helpers/test-helpers";
+
+import { SettingsService } from "../settings.service";
+
+describe("SettingsService - login background", () => {
+  let testContext: TestContext;
+  let service: SettingsService;
+
+  beforeAll(async () => {
+    testContext = await createUnitTest();
+    service = testContext.module.get<SettingsService>(SettingsService);
+  }, 30000);
+
+  afterAll(async () => {
+    await testContext.teardown();
+  });
+
+  beforeEach(async () => {
+    await truncateTables(testContext.db, ["settings"]);
+    const globalSettingsFactory = createSettingsFactory(testContext.db, null);
+    await globalSettingsFactory.create({ userId: null });
+  });
+
+  it("uploadLoginBackgroundImage should set loginBackgroundImageS3Key in global settings", async () => {
+    jest.spyOn((service as any).fileService, "uploadFile").mockResolvedValue({
+      fileKey: "login-backgrounds/mock.png",
+      fileUrl: "https://signed.example.com/login-backgrounds/mock.png",
+    });
+
+    const fakeFile = {
+      originalname: "mock.png",
+      buffer: Buffer.from("test"),
+      mimetype: "image/png",
+      size: 4,
+    } as unknown as Express.Multer.File;
+
+    await service.uploadLoginBackgroundImage(fakeFile);
+
+    const global = await testContext.db.query.settings.findFirst({
+      where: (s, { isNull }) => isNull(s.userId),
+    });
+
+    expect(global).toBeDefined();
+    // @ts-expect-error dynamic JSONB shape
+    expect(global?.settings?.loginBackgroundImageS3Key).toBe("login-backgrounds/mock.png");
+  });
+});

--- a/apps/api/src/settings/constants/settings.constants.ts
+++ b/apps/api/src/settings/constants/settings.constants.ts
@@ -12,6 +12,7 @@ export const DEFAULT_GLOBAL_SETTINGS = {
   enforceSSO: false,
   certificateBackgroundImage: null,
   platformLogoS3Key: null,
+  loginBackgroundImageS3Key: null,
   MFAEnforcedRoles: [],
   defaultCourseCurrency: "pln",
   inviteOnlyRegistration: false,

--- a/apps/api/src/settings/schemas/login-background.schema.ts
+++ b/apps/api/src/settings/schemas/login-background.schema.ts
@@ -1,0 +1,5 @@
+import { Type } from "@sinclair/typebox";
+
+export const loginBackgroundResponseSchema = Type.Object({
+  url: Type.Union([Type.String(), Type.Null()]),
+});

--- a/apps/api/src/settings/schemas/settings.schema.ts
+++ b/apps/api/src/settings/schemas/settings.schema.ts
@@ -20,6 +20,7 @@ export const globalSettingsJSONSchema = Type.Object({
   certificateBackgroundImage: Type.Union([Type.String(), Type.Null()]),
   companyInformation: Type.Optional(companyInformationJSONSchema),
   platformLogoS3Key: Type.Union([Type.String(), Type.Null()]),
+  loginBackgroundImageS3Key: Type.Union([Type.String(), Type.Null()]),
   MFAEnforcedRoles: Type.Array(Type.Enum(USER_ROLES)),
   defaultCourseCurrency: Type.Union(ALLOWED_CURRENCIES.map((currency) => Type.Literal(currency))),
   inviteOnlyRegistration: Type.Boolean(),

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -20,8 +20,10 @@ import { RolesGuard } from "src/common/guards/roles.guard";
 import { USER_ROLES } from "src/user/schemas/userRoles";
 
 const PLATFORM_LOGO_MAX_SIZE_BYTES = 10 * 1024 * 1024;
+const LOGIN_BACKGROUND_MAX_SIZE_BYTES = 10 * 1024 * 1024;
 
 import { CompanyInformaitonJSONSchema } from "./schemas/company-information.schema";
+import { loginBackgroundResponseSchema } from "./schemas/login-background.schema";
 import { platformLogoResponseSchema } from "./schemas/platform-logo.schema";
 import {
   adminSettingsJSONContentSchema,
@@ -170,13 +172,51 @@ export class SettingsController {
         logo: {
           type: "string",
           format: "binary",
+          nullable: true,
         },
       },
-      required: ["logo"],
     },
   })
-  async updatePlatformLogo(@UploadedFile() logo: Express.Multer.File): Promise<void> {
+  async updatePlatformLogo(@UploadedFile() logo: Express.Multer.File | null): Promise<void> {
     await this.settingsService.uploadPlatformLogo(logo);
+  }
+
+  @Get("login-background")
+  @Public()
+  @Validate({
+    response: baseResponse(loginBackgroundResponseSchema),
+  })
+  async getLoginBackground() {
+    const loginBackgroundImageS3Key = await this.settingsService.getLoginBackgroundImageUrl();
+    return new BaseResponse({ loginBackgroundImageS3Key });
+  }
+
+  @Patch("login-background")
+  @Roles(USER_ROLES.ADMIN)
+  @UseInterceptors(
+    FileInterceptor("login-background", {
+      limits: {
+        fileSize: LOGIN_BACKGROUND_MAX_SIZE_BYTES,
+      },
+    }),
+  )
+  @ApiConsumes("multipart/form-data")
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        "login-background": {
+          type: "string",
+          format: "binary",
+          nullable: true,
+        },
+      },
+    },
+  })
+  async updateLoginBackground(
+    @UploadedFile() loginBackground: Express.Multer.File | null,
+  ): Promise<void> {
+    await this.settingsService.uploadLoginBackgroundImage(loginBackground);
   }
 
   @Get("company-information")

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -1,10 +1,4 @@
-import {
-  BadRequestException,
-  Inject,
-  Injectable,
-  NotFoundException,
-  UnauthorizedException,
-} from "@nestjs/common";
+import { Inject, Injectable, NotFoundException, UnauthorizedException } from "@nestjs/common";
 import { eq, isNull, sql } from "drizzle-orm";
 
 import { DatabasePg } from "src/common";
@@ -51,7 +45,12 @@ export class SettingsService {
 
     const parsedSettings = this.parseGlobalSettings(globalSettings.settings);
 
-    const { certificateBackgroundImage, platformLogoS3Key, ...restOfSettings } = parsedSettings;
+    const {
+      certificateBackgroundImage,
+      platformLogoS3Key,
+      loginBackgroundImageS3Key,
+      ...restOfSettings
+    } = parsedSettings;
 
     const certificateBackgroundSignedUrl = certificateBackgroundImage
       ? await this.fileService.getFileUrl(certificateBackgroundImage)
@@ -61,9 +60,14 @@ export class SettingsService {
       ? await this.fileService.getFileUrl(platformLogoS3Key)
       : null;
 
+    const loginBackgroundSignedUrl = loginBackgroundImageS3Key
+      ? await this.fileService.getFileUrl(loginBackgroundImageS3Key)
+      : null;
+
     return {
       ...restOfSettings,
       platformLogoS3Key: platformLogoUrl,
+      loginBackgroundImageS3Key: loginBackgroundSignedUrl,
       certificateBackgroundImage: certificateBackgroundSignedUrl,
     };
   }
@@ -273,13 +277,13 @@ export class SettingsService {
     return this.parseGlobalSettings(updatedGlobalSettings);
   }
 
-  public async uploadPlatformLogo(file: Express.Multer.File): Promise<void> {
-    if (!file) {
-      throw new BadRequestException("No logo file provided");
+  public async uploadPlatformLogo(file: Express.Multer.File | null | undefined): Promise<void> {
+    let newValue: string | null = null;
+    if (file) {
+      const resource = "platform-logos";
+      const { fileKey } = await this.fileService.uploadFile(file, resource);
+      newValue = fileKey;
     }
-
-    const resource = "platform-logos";
-    const { fileKey } = await this.fileService.uploadFile(file, resource);
 
     await this.db
       .update(settings)
@@ -288,7 +292,7 @@ export class SettingsService {
           jsonb_set(
             settings.settings,
             '{platformLogoS3Key}',
-            to_jsonb(${fileKey}::text),
+            ${newValue ? sql`to_jsonb(${newValue}::text)` : sql`'null'::jsonb`},
             true
           )
         `,
@@ -306,6 +310,37 @@ export class SettingsService {
     }
 
     return await this.fileService.getFileUrl(platformLogoS3Key);
+  }
+
+  public async uploadLoginBackgroundImage(
+    file: Express.Multer.File | null | undefined,
+  ): Promise<void> {
+    let newValue: string | null = null;
+    if (file) {
+      const resource = "login-backgrounds";
+      const { fileKey } = await this.fileService.uploadFile(file, resource);
+      newValue = fileKey;
+    }
+
+    await this.db
+      .update(settings)
+      .set({
+        settings: sql`
+          jsonb_set(
+            settings.settings,
+            '{loginBackgroundImageS3Key}',
+            ${newValue ? sql`to_jsonb(${newValue}::text)` : sql`'null'::jsonb`},
+            true
+          )
+        `,
+      })
+      .where(isNull(settings.userId));
+  }
+
+  public async getLoginBackgroundImageUrl(): Promise<string | null> {
+    const globalSettings = await this.getGlobalSettings();
+
+    return globalSettings.loginBackgroundImageS3Key ?? null;
   }
 
   public async getCompanyInformation(): Promise<CompanyInformaitonJSONSchema> {

--- a/apps/api/src/storage/migrations/0040_add_login_background_image_to_global_settings.sql
+++ b/apps/api/src/storage/migrations/0040_add_login_background_image_to_global_settings.sql
@@ -1,0 +1,18 @@
+INSERT INTO settings (user_id, created_at, settings)
+SELECT 
+    NULL, 
+    NOW(), 
+    '{"loginBackgroundImageS3Key": null}'::JSONB
+WHERE NOT EXISTS (SELECT 1 FROM settings WHERE user_id IS NULL);
+
+UPDATE settings 
+SET settings = jsonb_set(
+    COALESCE(settings, '{}'::jsonb),
+    '{loginBackgroundImageS3Key}',
+    'null'::jsonb,
+    true
+)
+WHERE user_id IS NULL 
+AND NOT (settings ? 'loginBackgroundImageS3Key');
+
+

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -1159,12 +1159,53 @@
                 "properties": {
                   "logo": {
                     "type": "string",
-                    "format": "binary"
+                    "format": "binary",
+                    "nullable": true
                   }
-                },
-                "required": [
-                  "logo"
-                ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/settings/login-background": {
+      "get": {
+        "operationId": "SettingsController_getLoginBackground",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetLoginBackgroundResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "SettingsController_updateLoginBackground",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "login-background": {
+                    "type": "string",
+                    "format": "binary",
+                    "nullable": true
+                  }
+                }
               }
             }
           }
@@ -5731,6 +5772,16 @@
                   }
                 ]
               },
+              "loginBackgroundImageS3Key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "MFAEnforcedRoles": {
                 "type": "array",
                 "items": {
@@ -5789,6 +5840,7 @@
               "enforceSSO",
               "certificateBackgroundImage",
               "platformLogoS3Key",
+              "loginBackgroundImageS3Key",
               "MFAEnforcedRoles",
               "defaultCourseCurrency",
               "inviteOnlyRegistration",
@@ -6104,6 +6156,16 @@
                   }
                 ]
               },
+              "loginBackgroundImageS3Key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "MFAEnforcedRoles": {
                 "type": "array",
                 "items": {
@@ -6162,6 +6224,7 @@
               "enforceSSO",
               "certificateBackgroundImage",
               "platformLogoS3Key",
+              "loginBackgroundImageS3Key",
               "MFAEnforcedRoles",
               "defaultCourseCurrency",
               "inviteOnlyRegistration",
@@ -6225,6 +6288,16 @@
                   }
                 ]
               },
+              "loginBackgroundImageS3Key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "MFAEnforcedRoles": {
                 "type": "array",
                 "items": {
@@ -6283,6 +6356,7 @@
               "enforceSSO",
               "certificateBackgroundImage",
               "platformLogoS3Key",
+              "loginBackgroundImageS3Key",
               "MFAEnforcedRoles",
               "defaultCourseCurrency",
               "inviteOnlyRegistration",
@@ -6472,6 +6546,32 @@
         ]
       },
       "GetPlatformLogoResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "url"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "GetLoginBackgroundResponse": {
         "type": "object",
         "properties": {
           "data": {

--- a/apps/api/test/jest-setup.ts
+++ b/apps/api/test/jest-setup.ts
@@ -23,6 +23,10 @@ const filteredLog = (...args: any[]) => {
 beforeAll(async () => {
   applyFormats();
   setupValidation();
+  if (!process.env.MASTER_KEY) {
+    // 32-byte deterministic test key
+    process.env.MASTER_KEY = Buffer.from("0123456789abcdef0123456789abcdef").toString("base64");
+  }
   jest.spyOn(console, "log").mockImplementation(filteredLog);
 });
 

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -390,6 +390,7 @@ export interface GetPublicGlobalSettingsResponse {
       courtRegisterNumber?: string;
     };
     platformLogoS3Key: string | null;
+    loginBackgroundImageS3Key: string | null;
     MFAEnforcedRoles: ("admin" | "student" | "content_creator")[];
     defaultCourseCurrency: "pln" | "eur" | "gbp" | "usd";
     inviteOnlyRegistration: boolean;
@@ -473,6 +474,7 @@ export interface UpdateUnregisteredUserCoursesAccessibilityResponse {
       courtRegisterNumber?: string;
     };
     platformLogoS3Key: string | null;
+    loginBackgroundImageS3Key: string | null;
     MFAEnforcedRoles: ("admin" | "student" | "content_creator")[];
     defaultCourseCurrency: "pln" | "eur" | "gbp" | "usd";
     inviteOnlyRegistration: boolean;
@@ -493,6 +495,7 @@ export interface UpdateEnforceSSOResponse {
       courtRegisterNumber?: string;
     };
     platformLogoS3Key: string | null;
+    loginBackgroundImageS3Key: string | null;
     MFAEnforcedRoles: ("admin" | "student" | "content_creator")[];
     defaultCourseCurrency: "pln" | "eur" | "gbp" | "usd";
     inviteOnlyRegistration: boolean;
@@ -537,6 +540,12 @@ export interface UpdatePrimaryColorResponse {
 }
 
 export interface GetPlatformLogoResponse {
+  data: {
+    url: string | null;
+  };
+}
+
+export interface GetLoginBackgroundResponse {
   data: {
     url: string | null;
   };
@@ -3251,12 +3260,47 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     settingsControllerUpdatePlatformLogo: (
       data: {
         /** @format binary */
-        logo: File;
+        logo?: File | null;
       },
       params: RequestParams = {},
     ) =>
       this.request<void, any>({
         path: `/api/settings/platform-logo`,
+        method: "PATCH",
+        body: data,
+        type: ContentType.FormData,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name SettingsControllerGetLoginBackground
+     * @request GET:/api/settings/login-background
+     */
+    settingsControllerGetLoginBackground: (params: RequestParams = {}) =>
+      this.request<GetLoginBackgroundResponse, any>({
+        path: `/api/settings/login-background`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name SettingsControllerUpdateLoginBackground
+     * @request PATCH:/api/settings/login-background
+     */
+    settingsControllerUpdateLoginBackground: (
+      data: {
+        /** @format binary */
+        "login-background"?: File | null;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/api/settings/login-background`,
         method: "PATCH",
         body: data,
         type: ContentType.FormData,

--- a/apps/web/app/api/mutations/admin/useUploadBackgroundImage.ts
+++ b/apps/web/app/api/mutations/admin/useUploadBackgroundImage.ts
@@ -5,24 +5,27 @@ import { useTranslation } from "react-i18next";
 import { ApiClient } from "~/api/api-client";
 import { queryClient } from "~/api/queryClient";
 import { useToast } from "~/components/ui/use-toast";
-import { platformLogoQueryOptions } from "~/hooks/usePlatformLogo";
+import { loginBackgroundQueryOptions } from "~/hooks/useLoginBackground";
 
-interface UploadPlatformLogoOptions {
-  logo?: File | null;
+interface UploadBackgroundImageOptions {
+  backgroundImage: File | null;
 }
 
-export function useUploadPlatformLogo() {
+export function useUploadBackgroundImage() {
   const { toast } = useToast();
   const { t } = useTranslation();
 
   return useMutation({
-    mutationFn: async ({ logo }: UploadPlatformLogoOptions) => {
-      const response = await ApiClient.api.settingsControllerUpdatePlatformLogo({ logo });
+    mutationFn: async ({ backgroundImage }: UploadBackgroundImageOptions) => {
+      const response = await ApiClient.api.settingsControllerUpdateLoginBackground({
+        "login-background": backgroundImage,
+      });
+
       return response.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(platformLogoQueryOptions(t));
-      toast({ description: t("platformLogo.toast.logoUploadedSuccessfully") });
+      queryClient.invalidateQueries(loginBackgroundQueryOptions(t));
+      toast({ description: t("backgroundImage.toast.backgroundImageUploadedSuccessfully") });
     },
     onError: (error) => {
       if (error instanceof AxiosError) {

--- a/apps/web/app/hooks/useLoginBackground.ts
+++ b/apps/web/app/hooks/useLoginBackground.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+
+import { ApiClient } from "~/api/api-client";
+import { toast } from "~/components/ui/use-toast";
+
+import type i18n from "i18n";
+
+export const loginBackgroundQueryOptions = (t: typeof i18n.t) => ({
+  queryKey: ["login-background"],
+  queryFn: async () => {
+    try {
+      const response = await ApiClient.api.settingsControllerGetLoginBackground();
+
+      return response.data.data.url;
+    } catch (error) {
+      toast({ description: t("loginBackground.toast.loginBackgroundFetchError") });
+
+      return null;
+    }
+  },
+});
+
+export function useLoginBackground() {
+  const { t } = useTranslation();
+
+  return useQuery(loginBackgroundQueryOptions(t));
+}

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -1566,6 +1566,18 @@
     "title": "Organization Theme",
     "description": "Customize the appearance of your platform by selecting a theme color that reflects your organization's branding."
   },
+  "organizationLoginBackgroundImageUpload": {
+    "title": "Login Background Image Upload",
+    "description": "Upload a custom background image for the organization login page.",
+    "button": {
+      "removeBackgroundImage": "Remove Background Image"
+    },
+
+    "toast": {
+      "success": "Login background image changed successfully",
+      "error": "Error changing login background image"
+    }
+  },
   "files": {
     "import": {
       "noFileUploaded": "No file uploaded",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -1574,6 +1574,19 @@
     "title": "Motyw organizacji",
     "description": "Dostosuj wygląd swojej platformy, wybierając kolor, który odzwierciedla tożsamość Twojej marki."
   },
+
+  "organizationLoginBackgroundImageUpload": {
+    "title": "Przesyłanie obrazu tła logowania",
+    "description": "Wgraj własny obraz tła dla strony logowania organizacji.",
+    "button": {
+      "removeBackgroundImage": "Usuń obraz tła"
+    },
+
+    "toast": {
+      "success": "Obraz tła logowania został pomyślnie zmieniony",
+      "error": "Nie udało się zmienić obrazu tła logowania"
+    }
+  },
   "files": {
     "import": {
       "noFileUploaded": "Nie przesłano pliku",

--- a/apps/web/app/modules/Auth/Login.page.tsx
+++ b/apps/web/app/modules/Auth/Login.page.tsx
@@ -44,7 +44,11 @@ export default function LoginPage() {
   const { mutateAsync: loginUser } = useLoginUser();
 
   const {
-    data: { enforceSSO: isSSOEnforced, inviteOnlyRegistration: inviteOnlyRegistration },
+    data: {
+      enforceSSO: isSSOEnforced,
+      inviteOnlyRegistration: inviteOnlyRegistration,
+      loginBackgroundImageS3Key,
+    },
   } = useGlobalSettingsSuspense();
 
   const {
@@ -66,84 +70,96 @@ export default function LoginPage() {
   };
 
   return (
-    <Card className="mx-auto max-w-sm">
-      <CardHeader>
-        <CardTitle role="heading" className="text-2xl">
-          <div className="mb-6 flex justify-center">
-            <PlatformLogo className="h-16 w-auto py-3" alt="Platform Logo" />
-          </div>
-          {t("loginView.header")}
-        </CardTitle>
-        <CardDescription>
-          {isSSOEnforced ? t("loginView.subHeaderSSO") : t("loginView.subHeader")}
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {!isSSOEnforced && (
-          <form className="grid gap-4" onSubmit={handleSubmit(onSubmit)}>
-            <div className="grid gap-2">
-              <Label htmlFor="email">{t("loginView.field.email")}</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="user@example.com"
-                className={cn({ "border-red-500": errors.email })}
-                {...register("email")}
-              />
-              {errors.email && <div className="text-sm text-red-500">{errors.email.message}</div>}
+    <>
+      {loginBackgroundImageS3Key && (
+        <div
+          className="absolute inset-0 -z-10"
+          style={{
+            backgroundImage: `url(${loginBackgroundImageS3Key}) `,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+          }}
+        />
+      )}
+      <Card className="mx-auto max-w-sm">
+        <CardHeader>
+          <CardTitle role="heading" className="text-2xl">
+            <div className="mb-6 flex justify-center">
+              <PlatformLogo className="h-16 w-auto py-3" alt="Platform Logo" />
             </div>
-            <div className="grid gap-2">
-              <div className="flex items-center">
-                <Label htmlFor="password">{t("loginView.field.password")}</Label>
-                <Link
-                  to="/auth/password-recovery"
-                  className="ml-auto inline-block text-sm underline"
-                >
-                  {t("loginView.other.forgotPassword")}
-                </Link>
+            {t("loginView.header")}
+          </CardTitle>
+          <CardDescription>
+            {isSSOEnforced ? t("loginView.subHeaderSSO") : t("loginView.subHeader")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!isSSOEnforced && (
+            <form className="grid gap-4" onSubmit={handleSubmit(onSubmit)}>
+              <div className="grid gap-2">
+                <Label htmlFor="email">{t("loginView.field.email")}</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="user@example.com"
+                  className={cn({ "border-red-500": errors.email })}
+                  {...register("email")}
+                />
+                {errors.email && <div className="text-sm text-red-500">{errors.email.message}</div>}
               </div>
-              <Input
-                id="password"
-                type="password"
-                className={cn({ "border-red-500": errors.password })}
-                {...register("password")}
+              <div className="grid gap-2">
+                <div className="flex items-center">
+                  <Label htmlFor="password">{t("loginView.field.password")}</Label>
+                  <Link
+                    to="/auth/password-recovery"
+                    className="ml-auto inline-block text-sm underline"
+                  >
+                    {t("loginView.other.forgotPassword")}
+                  </Link>
+                </div>
+                <Input
+                  id="password"
+                  type="password"
+                  className={cn({ "border-red-500": errors.password })}
+                  {...register("password")}
+                />
+                {errors.password && (
+                  <div className="text-sm text-red-500">{errors.password.message}</div>
+                )}
+              </div>
+              <FormCheckbox
+                control={control}
+                name="rememberMe"
+                label={t("loginView.other.rememberMe")}
               />
-              {errors.password && (
-                <div className="text-sm text-red-500">{errors.password.message}</div>
-              )}
-            </div>
-            <FormCheckbox
-              control={control}
-              name="rememberMe"
-              label={t("loginView.other.rememberMe")}
+              <Button type="submit" className="w-full">
+                {t("loginView.button.login")}
+              </Button>
+            </form>
+          )}
+
+          {isAnyProviderEnabled && (
+            <SocialLogin
+              isSSOEnforced={isSSOEnforced}
+              isGoogleOAuthEnabled={isGoogleOAuthEnabled}
+              isMicrosoftOAuthEnabled={isMicrosoftOAuthEnabled}
+              isSlackOAuthEnabled={isSlackOAuthEnabled}
             />
-            <Button type="submit" className="w-full">
-              {t("loginView.button.login")}
-            </Button>
-          </form>
-        )}
+          )}
 
-        {isAnyProviderEnabled && (
-          <SocialLogin
-            isSSOEnforced={isSSOEnforced}
-            isGoogleOAuthEnabled={isGoogleOAuthEnabled}
-            isMicrosoftOAuthEnabled={isMicrosoftOAuthEnabled}
-            isSlackOAuthEnabled={isSlackOAuthEnabled}
-          />
-        )}
-
-        {!inviteOnlyRegistration && (
-          <div className="mt-4 text-center text-sm">
-            {t("loginView.other.dontHaveAccount")}{" "}
-            <Link to="/auth/register" className="underline">
-              {t("loginView.other.signUp")}
-            </Link>
-          </div>
-        )}
-        <p className="bottom-4 mt-4 text-center text-sm text-neutral-300">
-          {t("common.other.appVersion", { version })}
-        </p>
-      </CardContent>
-    </Card>
+          {!inviteOnlyRegistration && (
+            <div className="mt-4 text-center text-sm">
+              {t("loginView.other.dontHaveAccount")}{" "}
+              <Link to="/auth/register" className="underline">
+                {t("loginView.other.signUp")}
+              </Link>
+            </div>
+          )}
+          <p className="bottom-4 mt-4 text-center text-sm text-neutral-300">
+            {t("common.other.appVersion", { version })}
+          </p>
+        </CardContent>
+      </Card>
+    </>
   );
 }

--- a/apps/web/app/modules/Auth/PasswordRecovery.page.tsx
+++ b/apps/web/app/modules/Auth/PasswordRecovery.page.tsx
@@ -5,7 +5,9 @@ import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
 import { usePasswordRecovery } from "~/api/mutations/useRecoverPassword";
+import { useGlobalSettingsSuspense } from "~/api/queries/useGlobalSettings";
 import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { useToast } from "~/components/ui/use-toast";
@@ -22,6 +24,9 @@ export default function PasswordRecoveryPage() {
   const { mutateAsync: recoverPassword } = usePasswordRecovery();
   const { toast } = useToast();
   const { t } = useTranslation();
+  const {
+    data: { loginBackgroundImageS3Key },
+  } = useGlobalSettingsSuspense();
 
   const {
     register,
@@ -40,39 +45,53 @@ export default function PasswordRecoveryPage() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-4 py-12">
-      <div className="mx-auto w-full max-w-md space-y-8">
-        <div>
-          <h2 className="mt-6 text-center text-3xl font-bold tracking-tight">
-            {t("forgotPasswordView.header")}
-          </h2>
-          <p className="mt-2 text-center text-sm text-muted-foreground">
-            {t("forgotPasswordView.subHeader")}
-          </p>
-        </div>
-        <form className="space-y-6" action="#" onSubmit={handleSubmit(onSubmit)}>
-          <div className="grid gap-2">
-            <Label htmlFor="email">{t("forgotPasswordView.field.email")}</Label>
-            <Input
-              id="email"
-              type="email"
-              autoComplete="email"
-              placeholder="user@example.com"
-              className={cn({ "border-red-500": errors.email })}
-              {...register("email")}
-            />
-            {errors.email && <div className="text-sm text-red-500">{errors.email.message}</div>}
-          </div>
-          <Button type="submit" className="w-full">
-            {t("forgotPasswordView.button.resetPassword")}
-          </Button>
-        </form>
-        <div className="flex justify-center">
-          <Link to="/auth/login" className="text-sm font-medium text-muted-foreground">
-            {t("forgotPasswordView.button.backToLogin")}
-          </Link>
-        </div>
+    <>
+      {loginBackgroundImageS3Key && (
+        <div
+          className="absolute inset-0 -z-10"
+          style={{
+            backgroundImage: `url(${loginBackgroundImageS3Key}) `,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+          }}
+        />
+      )}
+      <div className="flex min-h-screen flex-col items-center justify-center px-4 py-12">
+        <Card className="mx-auto w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="mt-6 text-center text-3xl font-bold tracking-tight">
+              {t("forgotPasswordView.header")}
+            </CardTitle>
+            <CardDescription className="mt-2 text-center text-sm text-muted-foreground">
+              {t("forgotPasswordView.subHeader")}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="mt-3">
+            <form className="space-y-6" action="#" onSubmit={handleSubmit(onSubmit)}>
+              <div className="grid gap-2">
+                <Label htmlFor="email">{t("forgotPasswordView.field.email")}</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  placeholder="user@example.com"
+                  className={cn({ "border-red-500": errors.email })}
+                  {...register("email")}
+                />
+                {errors.email && <div className="text-sm text-red-500">{errors.email.message}</div>}
+              </div>
+              <Button type="submit" className="w-full">
+                {t("forgotPasswordView.button.resetPassword")}
+              </Button>
+            </form>
+            <div className="mt-8 flex justify-center">
+              <Link to="/auth/login" className="text-sm font-medium text-muted-foreground">
+                {t("forgotPasswordView.button.backToLogin")}
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/app/modules/Auth/Register.page.tsx
+++ b/apps/web/app/modules/Auth/Register.page.tsx
@@ -57,7 +57,11 @@ export default function RegisterPage() {
   });
 
   const {
-    data: { enforceSSO: isSSOEnforced, inviteOnlyRegistration: inviteOnlyRegistration },
+    data: {
+      enforceSSO: isSSOEnforced,
+      inviteOnlyRegistration: inviteOnlyRegistration,
+      loginBackgroundImageS3Key,
+    },
   } = useGlobalSettingsSuspense();
 
   const {
@@ -91,6 +95,16 @@ export default function RegisterPage() {
 
   return (
     <FormProvider {...methods}>
+      {loginBackgroundImageS3Key && (
+        <div
+          className="absolute inset-0 -z-10"
+          style={{
+            backgroundImage: `url(${loginBackgroundImageS3Key}) `,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+          }}
+        />
+      )}
       <Card className="mx-auto max-w-sm">
         <CardHeader>
           <CardTitle className="text-xl">{t("registerView.header")}</CardTitle>

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/OrganizationLoginBackgroundUpload.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/OrganizationLoginBackgroundUpload.tsx
@@ -1,0 +1,105 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRef } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+
+import { useUploadBackgroundImage } from "~/api/mutations/admin/useUploadBackgroundImage";
+import ImageUploadInput from "~/components/FileUploadInput/ImageUploadInput";
+import { Icon } from "~/components/Icon";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { useHandleImageUpload } from "~/hooks/useHandleImageUpload";
+
+const OrganizationLoginBackgroundUploadSchema = z.object({
+  backgroundImage: z.instanceof(File).nullable(),
+});
+
+interface OrganizationLoginBackgroundUploadProps {
+  backgroundImage: string | null;
+}
+
+export function OrganizationLoginBackgroundUpload({
+  backgroundImage: initialBackgroundImage,
+}: OrganizationLoginBackgroundUploadProps) {
+  const { t } = useTranslation();
+  const { mutate: uploadBackgroundImage, isPending } = useUploadBackgroundImage();
+  const { setValue, control } = useForm({
+    resolver: zodResolver(OrganizationLoginBackgroundUploadSchema),
+  });
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const {
+    imageUrl: backgroundImage,
+    isUploading,
+    handleImageUpload,
+    removeImage,
+  } = useHandleImageUpload({
+    onUpload: (file) => {
+      setValue("backgroundImage", file);
+    },
+    onRemove: () => {
+      setValue("backgroundImage", null);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    initialImageUrl: initialBackgroundImage,
+  });
+
+  const handleUploadBackgroundImage = () => {
+    const uploadedBackgroundImage = control._formValues.backgroundImage;
+    uploadBackgroundImage({
+      backgroundImage: uploadedBackgroundImage,
+    });
+  };
+
+  return (
+    <Card id="organization-login-background-image-upload">
+      <CardHeader>
+        <CardTitle>{t("organizationLoginBackgroundImageUpload.title")}</CardTitle>
+        <CardDescription>{t("organizationLoginBackgroundImageUpload.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Controller
+          name="backgroundImage"
+          control={control}
+          render={({ field }) => (
+            <div className="flex flex-col gap-y-2">
+              <ImageUploadInput
+                field={{
+                  ...field,
+                  value: backgroundImage || undefined,
+                }}
+                handleImageUpload={handleImageUpload}
+                isUploading={isUploading}
+                imageUrl={backgroundImage}
+                fileInputRef={fileInputRef}
+              />
+              {isUploading && <p>{t("common.button.uploading")}</p>}
+            </div>
+          )}
+        />
+        {backgroundImage && (
+          <Button onClick={removeImage} className="mt-4 rounded bg-red-500 px-6 py-2 text-white">
+            <Icon name="TrashIcon" className="mr-2" />
+            {t("organizationLoginBackgroundImageUpload.button.removeBackgroundImage")}
+          </Button>
+        )}
+      </CardContent>
+      <CardFooter className="border-t px-6 py-4">
+        <Button disabled={isPending} type="submit" onClick={handleUploadBackgroundImage}>
+          {t("common.button.save")}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/OrganizationTabContent.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/OrganizationTabContent.tsx
@@ -5,6 +5,7 @@ import SSOEnforceSwitch from "../SSOEnforceSwitch";
 
 import { CertificateBackgroundUpload } from "./CertificateBackgroundUpload";
 import { DefaultCourseCurrencySelect } from "./DefaultCourseCurrencySelect";
+import { OrganizationLoginBackgroundUpload } from "./OrganizationLoginBackgroundUpload";
 import { OrganizationTheme } from "./OrganizationTheme";
 import AdminPreferences from "./Preferences";
 import RoleBasedMFAEnforcementSwitch from "./RoleBasedMFAEnforcementSwitch";
@@ -35,6 +36,9 @@ export default function OrganizationTabContent({
       <DefaultCourseCurrencySelect currentCurrency={globalSettings.defaultCourseCurrency} />
       <CertificateBackgroundUpload
         certificateBackgroundImage={globalSettings.certificateBackgroundImage}
+      />
+      <OrganizationLoginBackgroundUpload
+        backgroundImage={globalSettings.loginBackgroundImageS3Key}
       />
       <PlatformLogoForm />
       <OrganizationTheme />

--- a/apps/web/app/modules/Dashboard/Settings/forms/PlatformLogoForm.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/forms/PlatformLogoForm.tsx
@@ -29,13 +29,11 @@ export const PlatformLogoForm = () => {
   const { data: currentLogoUrl } = usePlatformLogo();
   const { mutate: uploadLogo, isPending } = useUploadPlatformLogo();
 
-  const { control, handleSubmit, setValue, watch } = useForm<PlatformLogoFormData>({
+  const { control, handleSubmit, setValue } = useForm<PlatformLogoFormData>({
     defaultValues: {
       logo: null,
     },
   });
-
-  const watchedLogo = watch("logo");
 
   const {
     imageUrl: logoUrl,
@@ -56,9 +54,7 @@ export const PlatformLogoForm = () => {
   });
 
   const onSubmit = (data: PlatformLogoFormData) => {
-    if (data.logo) {
-      uploadLogo({ logo: data.logo });
-    }
+    uploadLogo({ logo: data.logo ?? null });
   };
 
   return (
@@ -97,7 +93,7 @@ export const PlatformLogoForm = () => {
           )}
         </CardContent>
         <CardFooter className="border-t px-6 py-4">
-          <Button type="submit" disabled={!watchedLogo || isPending}>
+          <Button type="submit" disabled={isPending}>
             {isPending ? t("common.button.uploading") : t("common.button.save")}
           </Button>
         </CardFooter>

--- a/apps/web/app/modules/Dashboard/Settings/types.ts
+++ b/apps/web/app/modules/Dashboard/Settings/types.ts
@@ -9,6 +9,7 @@ export type GlobalSettings = {
   certificateBackgroundImage: string | null;
   defaultCourseCurrency: GetPublicGlobalSettingsResponse["data"]["defaultCourseCurrency"];
   inviteOnlyRegistration: boolean;
+  loginBackgroundImageS3Key: string | null;
 };
 
 export type UserSettings = {


### PR DESCRIPTION
## Description
Adds admin setting to upload a custom login background image
Displays the uploaded background across auth pages (login, register, password recovery)

## Changes
**API:**
- New login-background schema and settings updates
- Controller/service extended to handle background image upload
- DB migration `0040_add_login_background_image_to_global_settings.sql`
- Swagger schema updated
- Unit and E2E tests added

**Web:**
- New `OrganizationLoginBackgroundUpload` component in Settings
- New hooks/mutations: `useLoginBackground`, `useUploadBackgroundImage`
- Auth pages updated to render background image
- EN/PL translations updated
- Regenerated API client

## Notes
- Requires running DB migration
- Backwards compatible: defaults apply if no image is set