### PR TITLE
fix: avoid app rendering errors during auth transitions

### DIFF
--- a/apps/web/app/modules/Dashboard/hooks/useSyncUserAfterLogin.ts
+++ b/apps/web/app/modules/Dashboard/hooks/useSyncUserAfterLogin.ts
@@ -1,17 +1,41 @@
+import { useEffect } from "react";
+
 import { useAuthStore } from "~/modules/Auth/authStore";
 import { useCurrentUserStore } from "~/modules/common/store/useCurrentUserStore";
 
 import type { CurrentUserResponse } from "~/api/generated-api";
 
 export const useSyncUserAfterLogin = (user?: CurrentUserResponse["data"]) => {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+  const currentUser = useCurrentUserStore((state) => state.currentUser);
   const setCurrentUser = useCurrentUserStore(({ setCurrentUser }) => setCurrentUser);
   const setHasVerifiedMFA = useCurrentUserStore((state) => state.setHasVerifiedMFA);
   const hasVerifiedMFA = useCurrentUserStore((state) => state.hasVerifiedMFA);
 
-  if (!hasVerifiedMFA && user?.shouldVerifyMFA) setHasVerifiedMFA(false);
-  if (hasVerifiedMFA || !user?.shouldVerifyMFA) setHasVerifiedMFA(true);
+  useEffect(() => {
+    if (!user) return;
 
-  setLoggedIn(true);
-  setCurrentUser(user);
+    const nextHasVerifiedMFA = user.shouldVerifyMFA ? hasVerifiedMFA : true;
+
+    if (hasVerifiedMFA !== nextHasVerifiedMFA) {
+      setHasVerifiedMFA(nextHasVerifiedMFA);
+    }
+
+    if (!isLoggedIn) {
+      setLoggedIn(true);
+    }
+
+    if (currentUser !== user) {
+      setCurrentUser(user);
+    }
+  }, [
+    currentUser,
+    hasVerifiedMFA,
+    isLoggedIn,
+    setCurrentUser,
+    setHasVerifiedMFA,
+    setLoggedIn,
+    user,
+  ]);
 };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
           v3_fetcherPersist: true,
           v3_relativeSplatPath: true,
           v3_throwAbortReason: true,
-          v3_singleFetch: true,
+          v3_singleFetch: false,
         },
         ssr: false, // SPA MODE - Might migrate to React Router 7
         routes,


### PR DESCRIPTION
## Issue(s)
[](https://github.com/Selleo/mentingo/issues/)

## Overview
Moves authentication and current-user Zustand synchronization out of the render phase in `useSyncUserAfterLogin`, preventing state updates while `UserDashboardLayout` is rendering.

Disables Remix `v3_singleFetch` in the SPA configuration because it was associated with intermittent React minified error #345 during reload and authentication transitions.

## Business Value
Improves reliability of login, logout, reload, and protected-route navigation by preventing the app from entering an incomplete React render state.

Validation completed:
- Web ESLint
- Web TypeScript check
- Production web build
- 86 web test files / 380 tests
- 72 API test suites / 413 tests