### PR TITLE
chore: take students directly to the first lesson after enrolling in a course

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverview.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverview.tsx
@@ -222,6 +222,10 @@ export default function CourseOverview({
     navigateToNextLesson(course, navigate, { openFirstLesson: isPreviewMode });
   };
 
+  const handleEnrollmentCompleted = () => {
+    navigateToNextLesson(course, navigate, { openFirstLesson: true });
+  };
+
   const handleOpenDescriptionModal = () => {
     setShowDescriptionModal(true);
   };
@@ -414,6 +418,7 @@ export default function CourseOverview({
               isTogglingLearningMode={isTogglingLearningMode}
               onToggleLearningMode={handleToggleLearningMode}
               onContinueLearning={handleContinueLearning}
+              onEnrollmentCompleted={handleEnrollmentCompleted}
               onOpenDetails={handleOpenDescriptionModal}
             />
           </div>

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.test.tsx
@@ -54,9 +54,11 @@ vi.mock("../../context/CourseAccessProvider", () => ({
 
 const renderActions = ({
   onContinueLearning = vi.fn(),
+  onEnrollmentCompleted = vi.fn(),
   onToggleLearningMode = vi.fn(),
 }: {
   onContinueLearning?: () => void;
+  onEnrollmentCompleted?: () => void;
   onToggleLearningMode?: () => void;
 } = {}) =>
   renderWith().render(
@@ -68,6 +70,7 @@ const renderActions = ({
             <CourseOverviewActions
               isTogglingLearningMode={false}
               onContinueLearning={onContinueLearning}
+              onEnrollmentCompleted={onEnrollmentCompleted}
               onOpenDetails={vi.fn()}
               onToggleLearningMode={onToggleLearningMode}
             />
@@ -133,6 +136,19 @@ describe("CourseOverviewActions", () => {
     await user.click(screen.getByTestId(COURSE_OVERVIEW_HANDLES.START_LEARNING_BUTTON));
 
     expect(onContinueLearning).toHaveBeenCalledOnce();
+  });
+
+  it("notifies the overview after enrollment succeeds", async () => {
+    const user = userEvent.setup();
+    const onEnrollmentCompleted = vi.fn();
+    currentUser = { id: "user-1" };
+
+    renderActions({ onEnrollmentCompleted });
+
+    await user.click(screen.getByTestId(COURSE_OVERVIEW_HANDLES.ENROLL_BUTTON));
+
+    expect(enrollCourse).toHaveBeenCalledWith({ id: "course-1" });
+    expect(onEnrollmentCompleted).toHaveBeenCalledOnce();
   });
 
   it("keeps course actions available on small screens", () => {

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.tsx
@@ -21,6 +21,7 @@ import { useCourseAccessProvider } from "../../context/CourseAccessProvider";
 type CourseOverviewActionsProps = {
   isTogglingLearningMode: boolean;
   onContinueLearning: () => void;
+  onEnrollmentCompleted: () => void;
   onOpenDetails: () => void;
   onToggleLearningMode: () => void;
 };
@@ -28,6 +29,7 @@ type CourseOverviewActionsProps = {
 export default function CourseOverviewActions({
   isTogglingLearningMode,
   onContinueLearning,
+  onEnrollmentCompleted,
   onOpenDetails,
   onToggleLearningMode,
 }: CourseOverviewActionsProps) {
@@ -49,6 +51,7 @@ export default function CourseOverviewActions({
       queryClient.invalidateQueries(availableCoursesQueryOptions({ language })),
       queryClient.invalidateQueries(studentCoursesQueryOptions({ language })),
     ]);
+    onEnrollmentCompleted();
   };
 
   const renderPrimaryAction = () => {

--- a/apps/web/app/modules/Dashboard/Settings/components/admin/CoursesAccessibilityPreferences.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/admin/CoursesAccessibilityPreferences.tsx
@@ -96,6 +96,7 @@ export default function CoursesAccessibilityPreferences({
                     <RadioGroupItem
                       value={layout}
                       id={layout}
+                      data-testid={SETTINGS_PAGE_HANDLES.courseListLayoutOption(layout)}
                       className={cn("mt-0.5 size-5 shrink-0 border-neutral-300 bg-white", {
                         "border-primary-700 text-primary-700": isSelected,
                       })}

--- a/apps/web/e2e/data/settings/handles.ts
+++ b/apps/web/e2e/data/settings/handles.ts
@@ -74,7 +74,7 @@ export const SETTINGS_PAGE_HANDLES = {
   LOGIN_PAGE_FILE_PREVIEW_CLOSE: "settings-login-page-file-preview-close",
   ADMIN_PREFERENCES_CARD: "settings-admin-preferences-card",
   COURSES_VISIBILITY_SWITCH: "settings-courses-visibility-switch",
-  MODERN_COURSE_LIST_SWITCH: "settings-modern-course-list-switch",
+  courseListLayoutOption: (layout: string) => `settings-course-list-layout-${layout}`,
   COURSE_DISCUSSIONS_SWITCH: "settings-course-discussions-switch",
   CALENDAR_SWITCH: "settings-calendar-switch",
   LIVE_TRAINING_SWITCH: "settings-live-training-switch",

--- a/apps/web/e2e/flows/courses/self-enroll-course.flow.ts
+++ b/apps/web/e2e/flows/courses/self-enroll-course.flow.ts
@@ -5,5 +5,4 @@ import type { Page } from "@playwright/test";
 export const selfEnrollCourseFlow = async (page: Page, courseIdOrSlug: string) => {
   await page.goto(`/course/${courseIdOrSlug}`);
   await page.getByTestId(COURSE_OVERVIEW_HANDLES.ENROLL_BUTTON).click();
-  await page.getByTestId(COURSE_OVERVIEW_HANDLES.START_LEARNING_BUTTON).waitFor();
 };

--- a/apps/web/e2e/specs/course-enrollment/self-enroll-course.spec.ts
+++ b/apps/web/e2e/specs/course-enrollment/self-enroll-course.spec.ts
@@ -1,43 +1,33 @@
 import { USER_ROLE } from "~/config/userRoles";
 
+import { LEARNING_HANDLES } from "../../data/learning/handles";
 import { expect, test } from "../../fixtures/test.fixture";
 import { selfEnrollCourseFlow } from "../../flows/courses/self-enroll-course.flow";
+import { createTwoContentLessonsCourse } from "../learning/learning-test-helpers";
 
 test("student can self-enroll in a free published course", async ({
   cleanup,
   factories,
   withWorkerPage,
 }) => {
-  const categoryFactory = factories.createCategoryFactory();
-  const courseFactory = factories.createCourseFactory();
   const enrollmentFactory = factories.createEnrollmentFactory();
-  let categoryId = "";
-  let courseId = "";
   let studentUserId = "";
 
-  await withWorkerPage(USER_ROLE.admin, async () => {
-    const prefix = `self-enroll-${Date.now()}`;
-    const category = await categoryFactory.create(`Self Enroll Category ${prefix}`);
-    const course = await courseFactory.create({
-      title: `${prefix}-course`,
-      categoryId: category.id,
-      status: "published",
-    });
-
-    categoryId = category.id;
-    courseId = course.id;
-
-    cleanup.add(async () => {
-      await courseFactory.update(courseId, { status: "draft", language: "en" });
-      await courseFactory.delete(courseId);
-      await categoryFactory.delete(categoryId);
-    });
+  const { courseId, lessons } = await createTwoContentLessonsCourse({
+    cleanup,
+    factories,
+    prefix: `self-enroll-${Date.now()}`,
+    withWorkerPage,
   });
 
   await withWorkerPage(USER_ROLE.student, async ({ page }) => {
     studentUserId = await enrollmentFactory.getCurrentUserId();
 
     await selfEnrollCourseFlow(page, courseId);
+    await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${lessons.firstLesson.id}$`));
+    await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(
+      lessons.firstLesson.title,
+    );
   });
 
   await withWorkerPage(USER_ROLE.admin, async () => {

--- a/apps/web/e2e/specs/course-enrollment/self-enroll-course.spec.ts
+++ b/apps/web/e2e/specs/course-enrollment/self-enroll-course.spec.ts
@@ -20,23 +20,31 @@ test("student can self-enroll in a free published course", async ({
     withWorkerPage,
   });
 
-  await withWorkerPage(USER_ROLE.student, async ({ page }) => {
-    studentUserId = await enrollmentFactory.getCurrentUserId();
+  await withWorkerPage(
+    USER_ROLE.student,
+    async ({ page }) => {
+      studentUserId = await enrollmentFactory.getCurrentUserId();
 
-    await selfEnrollCourseFlow(page, courseId);
-    await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${lessons.firstLesson.id}$`));
-    await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(
-      lessons.firstLesson.title,
-    );
-  });
+      await selfEnrollCourseFlow(page, courseId);
+      await expect(page).toHaveURL(new RegExp(`/course/.+/lesson/${lessons.firstLesson.id}$`));
+      await expect(page.getByTestId(LEARNING_HANDLES.LESSON_TITLE)).toHaveText(
+        lessons.firstLesson.title,
+      );
+    },
+    { root: true },
+  );
 
-  await withWorkerPage(USER_ROLE.admin, async () => {
-    await expect
-      .poll(async () => {
-        const enrolledUser = await enrollmentFactory.getUser(courseId, studentUserId);
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async () => {
+      await expect
+        .poll(async () => {
+          const enrolledUser = await enrollmentFactory.getUser(courseId, studentUserId);
 
-        return Boolean(enrolledUser?.enrolledAt);
-      })
-      .toBe(true);
-  });
+          return Boolean(enrolledUser?.enrolledAt);
+        })
+        .toBe(true);
+    },
+    { root: true },
+  );
 });

--- a/apps/web/e2e/specs/settings/platform-preferences.spec.ts
+++ b/apps/web/e2e/specs/settings/platform-preferences.spec.ts
@@ -1,4 +1,5 @@
 import { USER_ROLE } from "~/config/userRoles";
+import { COURSE_LIST_LAYOUT_VARIANT } from "~/modules/Dashboard/Settings/components/admin/courseListLayout";
 
 import { QA_SETTINGS_HANDLES } from "../../data/qa/handles";
 import { SETTINGS_PAGE_HANDLES } from "../../data/settings/handles";
@@ -55,7 +56,14 @@ test("admin can toggle course platform settings", async ({
     await openPlatformCustomizationSettings(page);
 
     await page.getByTestId(SETTINGS_PAGE_HANDLES.COURSES_VISIBILITY_SWITCH).click();
-    await page.getByTestId(SETTINGS_PAGE_HANDLES.MODERN_COURSE_LIST_SWITCH).click();
+
+    const nextCourseListLayout = originalSettings.modernCourseListEnabled
+      ? COURSE_LIST_LAYOUT_VARIANT.CLASSIC
+      : COURSE_LIST_LAYOUT_VARIANT.MODERN;
+
+    await page
+      .getByTestId(SETTINGS_PAGE_HANDLES.courseListLayoutOption(nextCourseListLayout))
+      .click();
     await page.getByTestId(SETTINGS_PAGE_HANDLES.COURSE_DISCUSSIONS_SWITCH).click();
 
     await expect

--- a/docs/specs/course-enrollment-business-spec.md
+++ b/docs/specs/course-enrollment-business-spec.md
@@ -34,7 +34,7 @@ Group enrollment also makes recurring HR and L&D workflows easier: onboarding co
 
 ## How It Works
 
-Learners enroll from the course detail experience when the course is published and available to them. Once enrolled, they can begin the course because Mentingo prepares chapter and lesson progress tracking for that learner.
+Learners enroll from the course detail experience when the course is published and available to them. After a successful enrollment from the course overview, Mentingo takes them directly to the first lesson and prepares chapter and lesson progress tracking. Selecting an unenrolled course from the course list still opens its overview first, so learners can review the course before enrolling.
 
 Administrators manage assignment from the course edit screen. The enrolled-users table shows direct enrollment, group enrollment, and not-enrolled states. Admins can select rows for direct enrollment or unenrollment, and they can open group dialogs to add or remove group-based access.
 
@@ -43,7 +43,7 @@ When a group is enrolled, Mentingo links the group to the course and grants acce
 ## Key Technical Context
 
 - Frontend enrollment management lives in `apps/web/app/modules/Admin/EditCourse/CourseEnrolled`.
-- Learner self-enrollment is initiated from the course view.
+- Learner self-enrollment is initiated from the course overview and continues directly to the first lesson after success; course-list cards continue to open the overview.
 - API enrollment operations live in `apps/api/src/courses/course.controller.ts`.
 - Key permissions include `PERMISSIONS.COURSE_ENROLLMENT` for admin assignment and `PERMISSIONS.LEARNING_PROGRESS_UPDATE` for learner-side progress initialization.
 - Group due dates connect enrollment with calendar events and due-date reminders.


### PR DESCRIPTION
## Issue(s)
- #1783 

## Overview

After a learner enrolls in a course from its overview, Mentingo now redirects them directly to the course's first lesson. The existing course-list behavior remains unchanged.

The change uses the existing course lesson navigation helper, adds component coverage for the enrollment completion callback, and updates the self-enrollment E2E scenario to verify the destination lesson.

## Business Value

Learners can begin training immediately after enrollment without needing to click the learning button a second time. This reduces friction in self-service learning flows while preserving the course-list experience where learners first review the course overview.


https://github.com/user-attachments/assets/77e29896-ac05-4d0f-aa39-c5840ba0afd5

