### PR TITLE
chore: show additional activity details in the activity logs table

### DIFF
--- a/apps/api/src/activity-logs/__tests__/activity-logs.controller.e2e-spec.ts
+++ b/apps/api/src/activity-logs/__tests__/activity-logs.controller.e2e-spec.ts
@@ -6,6 +6,7 @@ import { DB, DB_ADMIN } from "src/storage/db/db.providers";
 import { activityLogs } from "src/storage/schema";
 
 import { createE2ETest } from "../../../test/create-e2e-test";
+import { createCourseFactory } from "../../../test/factory/course.factory";
 import { createUserFactory } from "../../../test/factory/user.factory";
 import { cookieFor, truncateAllTables } from "../../../test/helpers/test-helpers";
 import { ACTIVITY_LOG_ACTION_TYPES, ACTIVITY_LOG_RESOURCE_TYPES } from "../types";
@@ -18,6 +19,7 @@ describe("ActivityLogsController (e2e)", () => {
   let db: DatabasePg;
   let baseDb: DatabasePg;
   let userFactory: ReturnType<typeof createUserFactory>;
+  let courseFactory: ReturnType<typeof createCourseFactory>;
 
   const password = "password123";
 
@@ -27,6 +29,7 @@ describe("ActivityLogsController (e2e)", () => {
     db = app.get(DB);
     baseDb = app.get(DB_ADMIN);
     userFactory = createUserFactory(db);
+    courseFactory = createCourseFactory(db);
   }, 30000);
 
   afterAll(async () => {
@@ -86,6 +89,52 @@ describe("ActivityLogsController (e2e)", () => {
     expect(response.body.data[0]).toHaveProperty("createdAt");
     expect(response.body.data[0]).toHaveProperty("actorEmail", admin.email);
     expect(response.body.data[0]).toHaveProperty("metadata");
+  });
+
+  it("returns event-time or current resource names for course activity", async () => {
+    const admin = await userFactory
+      .withCredentials({ password })
+      .withAdminSettings(db)
+      .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+    const course = await courseFactory.create({ title: "Current course title" });
+
+    const [metadataFreeLog, eventTimeLog] = await db
+      .insert(activityLogs)
+      .values([
+        {
+          actorId: admin.id,
+          actorEmail: admin.email,
+          actorRole: SYSTEM_ROLE_SLUGS.ADMIN,
+          actionType: ACTIVITY_LOG_ACTION_TYPES.ENROLL_COURSE,
+          resourceType: ACTIVITY_LOG_RESOURCE_TYPES.COURSE,
+          resourceId: course.id,
+          metadata: { operation: ACTIVITY_LOG_ACTION_TYPES.ENROLL_COURSE },
+        },
+        {
+          actorId: admin.id,
+          actorEmail: admin.email,
+          actorRole: SYSTEM_ROLE_SLUGS.ADMIN,
+          actionType: ACTIVITY_LOG_ACTION_TYPES.UPDATE,
+          resourceType: ACTIVITY_LOG_RESOURCE_TYPES.COURSE,
+          resourceId: course.id,
+          metadata: {
+            operation: ACTIVITY_LOG_ACTION_TYPES.UPDATE,
+            after: { title: "Event-time course title" },
+          },
+        },
+      ])
+      .returning({ id: activityLogs.id });
+
+    const response = await request(app.getHttpServer())
+      .get("/api/activity-logs")
+      .set("Cookie", await cookieFor(admin, app))
+      .expect(200);
+    const logsById = new Map<string, { id: string; resourceName: string | null }>(
+      response.body.data.map((log: { id: string; resourceName: string | null }) => [log.id, log]),
+    );
+
+    expect(logsById.get(metadataFreeLog.id)?.resourceName).toBe("Current course title");
+    expect(logsById.get(eventTimeLog.id)?.resourceName).toBe("Event-time course title");
   });
 
   it("includes logs created on the to date", async () => {

--- a/apps/api/src/activity-logs/activity-log-resource-name.service.spec.ts
+++ b/apps/api/src/activity-logs/activity-log-resource-name.service.spec.ts
@@ -1,0 +1,44 @@
+import { ACTIVITY_LOG_RESOURCE_TYPES, type ActivityLogResourceType } from "@repo/shared";
+
+import { ActivityLogResourceNameService } from "./activity-log-resource-name.service";
+
+import type { DatabasePg, UUIDType } from "src/common";
+import type { LocalizationService } from "src/localization/localization.service";
+
+describe("ActivityLogResourceNameService", () => {
+  it("deduplicates IDs and resolves each resource type in one batch", async () => {
+    const service = new ActivityLogResourceNameService({} as DatabasePg, {} as LocalizationService);
+    const fetchResourceNamesByType = jest
+      .spyOn(service as unknown as ResourceNameFetcher, "fetchResourceNamesByType")
+      .mockImplementation(async (resourceType, ids) =>
+        ids.map((id) => ({ id, name: `${resourceType} name` })),
+      );
+
+    const names = await service.resolveCurrentResourceNames([
+      { resourceType: ACTIVITY_LOG_RESOURCE_TYPES.COURSE, resourceId: "course-id" },
+      { resourceType: ACTIVITY_LOG_RESOURCE_TYPES.COURSE, resourceId: "course-id" },
+      { resourceType: ACTIVITY_LOG_RESOURCE_TYPES.GROUP, resourceId: "group-id" },
+    ]);
+
+    expect(fetchResourceNamesByType).toHaveBeenCalledTimes(2);
+    expect(fetchResourceNamesByType).toHaveBeenCalledWith(ACTIVITY_LOG_RESOURCE_TYPES.COURSE, [
+      "course-id",
+    ]);
+    expect(fetchResourceNamesByType).toHaveBeenCalledWith(ACTIVITY_LOG_RESOURCE_TYPES.GROUP, [
+      "group-id",
+    ]);
+    expect(names).toEqual(
+      new Map([
+        [`${ACTIVITY_LOG_RESOURCE_TYPES.COURSE}:course-id`, "course name"],
+        [`${ACTIVITY_LOG_RESOURCE_TYPES.GROUP}:group-id`, "group name"],
+      ]),
+    );
+  });
+});
+
+type ResourceNameFetcher = {
+  fetchResourceNamesByType: (
+    resourceType: ActivityLogResourceType,
+    ids: UUIDType[],
+  ) => Promise<Array<{ id: string; name: string }>>;
+};

--- a/apps/api/src/activity-logs/activity-log-resource-name.service.ts
+++ b/apps/api/src/activity-logs/activity-log-resource-name.service.ts
@@ -1,9 +1,14 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { ACTIVITY_LOG_RESOURCE_TYPES, type ActivityLogResourceType } from "@repo/shared";
+import {
+  ACTIVITY_LOG_RESOURCE_TYPES,
+  SCORM_PACKAGE_ENTITY_TYPE,
+  type ActivityLogResourceType,
+} from "@repo/shared";
 import { eq, inArray, sql } from "drizzle-orm";
 
 import { DatabasePg, type UUIDType } from "src/common";
 import { LocalizationService } from "src/localization/localization.service";
+import { DB } from "src/storage/db/db.providers";
 import {
   announcements,
   articleSections,
@@ -22,19 +27,21 @@ import {
   users,
 } from "src/storage/schema";
 
-import type { ActivityLogResponse } from "./activity-logs.types";
-
-type ResourceReference = Pick<ActivityLogResponse, "resourceId" | "resourceType">;
-type NamedResource = { id: string; name: string };
+import type {
+  ActivityLogResourceReference,
+  NamedActivityLogResource,
+} from "./activity-log-resource-name.types";
 
 @Injectable()
 export class ActivityLogResourceNameService {
   constructor(
-    @Inject("DB") private readonly db: DatabasePg,
+    @Inject(DB) private readonly db: DatabasePg,
     private readonly localizationService: LocalizationService,
   ) {}
 
-  async resolveCurrentResourceNames(resources: ResourceReference[]): Promise<Map<string, string>> {
+  async resolveCurrentResourceNames(
+    resources: ActivityLogResourceReference[],
+  ): Promise<Map<string, string>> {
     const resourcesByType = this.groupUniqueResourceIdsByType(resources);
 
     const resolvedResources = await Promise.all(
@@ -67,7 +74,7 @@ export class ActivityLogResourceNameService {
     return `${resourceType}:${resourceId}`;
   }
 
-  private groupUniqueResourceIdsByType(resources: ResourceReference[]) {
+  private groupUniqueResourceIdsByType(resources: ActivityLogResourceReference[]) {
     const resourcesByType = new Map<ActivityLogResourceType, Set<UUIDType>>();
 
     for (const { resourceType, resourceId } of resources) {
@@ -85,7 +92,7 @@ export class ActivityLogResourceNameService {
   private async fetchResourceNamesByType(
     resourceType: ActivityLogResourceType,
     ids: UUIDType[],
-  ): Promise<NamedResource[]> {
+  ): Promise<NamedActivityLogResource[]> {
     switch (resourceType) {
       case ACTIVITY_LOG_RESOURCE_TYPES.USER:
         return this.db
@@ -230,7 +237,7 @@ export class ActivityLogResourceNameService {
     }
   }
 
-  private async fetchScormResourceNames(ids: UUIDType[]): Promise<NamedResource[]> {
+  private async fetchScormResourceNames(ids: UUIDType[]): Promise<NamedActivityLogResource[]> {
     const packages = await this.db
       .select({
         id: scormPackages.id,
@@ -241,11 +248,11 @@ export class ActivityLogResourceNameService {
       .where(inArray(scormPackages.id, ids));
 
     const courseIds = packages
-      .filter(({ entityType }) => entityType === "course")
+      .filter(({ entityType }) => entityType === SCORM_PACKAGE_ENTITY_TYPE.COURSE)
       .map(({ entityId }) => entityId);
 
     const lessonIds = packages
-      .filter(({ entityType }) => entityType === "lesson")
+      .filter(({ entityType }) => entityType === SCORM_PACKAGE_ENTITY_TYPE.LESSON)
       .map(({ entityId }) => entityId);
 
     const [courseNames, lessonNames] = await Promise.all([

--- a/apps/api/src/activity-logs/activity-log-resource-name.service.ts
+++ b/apps/api/src/activity-logs/activity-log-resource-name.service.ts
@@ -1,0 +1,278 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { ACTIVITY_LOG_RESOURCE_TYPES, type ActivityLogResourceType } from "@repo/shared";
+import { eq, inArray, sql } from "drizzle-orm";
+
+import { DatabasePg, type UUIDType } from "src/common";
+import { LocalizationService } from "src/localization/localization.service";
+import {
+  announcements,
+  articleSections,
+  articles,
+  calendarEvents,
+  categories,
+  chapters,
+  courses,
+  groups,
+  learningPaths,
+  lessons,
+  liveTrainings,
+  news,
+  questionsAndAnswers,
+  scormPackages,
+  users,
+} from "src/storage/schema";
+
+import type { ActivityLogResponse } from "./activity-logs.types";
+
+type ResourceReference = Pick<ActivityLogResponse, "resourceId" | "resourceType">;
+type NamedResource = { id: string; name: string };
+
+@Injectable()
+export class ActivityLogResourceNameService {
+  constructor(
+    @Inject("DB") private readonly db: DatabasePg,
+    private readonly localizationService: LocalizationService,
+  ) {}
+
+  async resolveCurrentResourceNames(resources: ResourceReference[]): Promise<Map<string, string>> {
+    const resourcesByType = this.groupUniqueResourceIdsByType(resources);
+
+    const resolvedResources = await Promise.all(
+      [...resourcesByType].map(async ([resourceType, ids]) => ({
+        resourceType,
+        resources: await this.fetchResourceNamesByType(resourceType, [...ids]),
+      })),
+    );
+
+    return new Map(
+      resolvedResources.flatMap(({ resourceType, resources: namedResources }) =>
+        namedResources.flatMap(({ id, name }) =>
+          name ? [[this.buildResourceLookupKey(resourceType, id), name] as const] : [],
+        ),
+      ),
+    );
+  }
+
+  findResolvedResourceName(
+    names: Map<string, string>,
+    resourceType: string | null,
+    resourceId: string | null,
+  ): string | null {
+    if (!resourceType || !resourceId) return null;
+
+    return names.get(this.buildResourceLookupKey(resourceType, resourceId)) ?? null;
+  }
+
+  private buildResourceLookupKey(resourceType: string, resourceId: string) {
+    return `${resourceType}:${resourceId}`;
+  }
+
+  private groupUniqueResourceIdsByType(resources: ResourceReference[]) {
+    const resourcesByType = new Map<ActivityLogResourceType, Set<UUIDType>>();
+
+    for (const { resourceType, resourceId } of resources) {
+      if (!resourceType || !resourceId) continue;
+
+      const typedResource = resourceType as ActivityLogResourceType;
+      const resourceIds = resourcesByType.get(typedResource) ?? new Set<UUIDType>();
+      resourceIds.add(resourceId);
+      resourcesByType.set(typedResource, resourceIds);
+    }
+
+    return resourcesByType;
+  }
+
+  private async fetchResourceNamesByType(
+    resourceType: ActivityLogResourceType,
+    ids: UUIDType[],
+  ): Promise<NamedResource[]> {
+    switch (resourceType) {
+      case ACTIVITY_LOG_RESOURCE_TYPES.USER:
+        return this.db
+          .select({
+            id: users.id,
+            name: sql<string>`TRIM(CONCAT_WS(' ', ${users.firstName}, ${users.lastName}))`,
+          })
+          .from(users)
+          .where(inArray(users.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.COURSE:
+        return this.db
+          .select({
+            id: courses.id,
+            name: this.localizationService.getLocalizedSqlField(courses.title),
+          })
+          .from(courses)
+          .where(inArray(courses.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.CHAPTER:
+        return this.db
+          .select({
+            id: chapters.id,
+            name: this.localizationService.getLocalizedSqlField(chapters.title),
+          })
+          .from(chapters)
+          .innerJoin(courses, eq(courses.id, chapters.courseId))
+          .where(inArray(chapters.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.LESSON:
+        return this.db
+          .select({
+            id: lessons.id,
+            name: this.localizationService.getLocalizedSqlField(lessons.title),
+          })
+          .from(lessons)
+          .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
+          .innerJoin(courses, eq(courses.id, chapters.courseId))
+          .where(inArray(lessons.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.ANNOUNCEMENT:
+        return this.db
+          .select({
+            id: announcements.id,
+            name: this.localizationService.getLocalizedSqlField(
+              announcements.title,
+              undefined,
+              announcements,
+            ),
+          })
+          .from(announcements)
+          .where(inArray(announcements.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.GROUP:
+        return this.db
+          .select({
+            id: groups.id,
+            name: this.localizationService.getLocalizedSqlField(groups.name, undefined, groups),
+          })
+          .from(groups)
+          .where(inArray(groups.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.CATEGORY:
+        return this.db
+          .select({
+            id: categories.id,
+            name: this.localizationService.getLocalizedSqlField(
+              categories.title,
+              undefined,
+              categories,
+            ),
+          })
+          .from(categories)
+          .where(inArray(categories.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.QA:
+        return this.db
+          .select({
+            id: questionsAndAnswers.id,
+            name: this.localizationService.getLocalizedSqlField(
+              questionsAndAnswers.title,
+              undefined,
+              questionsAndAnswers,
+            ),
+          })
+          .from(questionsAndAnswers)
+          .where(inArray(questionsAndAnswers.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.NEWS:
+        return this.db
+          .select({
+            id: news.id,
+            name: this.localizationService.getLocalizedSqlField(news.title, undefined, news),
+          })
+          .from(news)
+          .where(inArray(news.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE:
+        return this.db
+          .select({
+            id: articles.id,
+            name: this.localizationService.getLocalizedSqlField(
+              articles.title,
+              undefined,
+              articles,
+            ),
+          })
+          .from(articles)
+          .where(inArray(articles.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE_SECTION:
+        return this.db
+          .select({
+            id: articleSections.id,
+            name: this.localizationService.getLocalizedSqlField(
+              articleSections.title,
+              undefined,
+              articleSections,
+            ),
+          })
+          .from(articleSections)
+          .where(inArray(articleSections.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.LIVE_TRAINING:
+        return this.db
+          .select({
+            id: liveTrainings.id,
+            name: this.localizationService.getLocalizedSqlField(
+              calendarEvents.title,
+              undefined,
+              calendarEvents,
+            ),
+          })
+          .from(liveTrainings)
+          .innerJoin(calendarEvents, eq(calendarEvents.id, liveTrainings.calendarEventId))
+          .where(inArray(liveTrainings.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.LEARNING_PATH:
+        return this.db
+          .select({
+            id: learningPaths.id,
+            name: this.localizationService.getLocalizedSqlField(
+              learningPaths.title,
+              undefined,
+              learningPaths,
+            ),
+          })
+          .from(learningPaths)
+          .where(inArray(learningPaths.id, ids));
+      case ACTIVITY_LOG_RESOURCE_TYPES.SCORM:
+        return this.fetchScormResourceNames(ids);
+      default:
+        return [];
+    }
+  }
+
+  private async fetchScormResourceNames(ids: UUIDType[]): Promise<NamedResource[]> {
+    const packages = await this.db
+      .select({
+        id: scormPackages.id,
+        entityId: scormPackages.entityId,
+        entityType: scormPackages.entityType,
+      })
+      .from(scormPackages)
+      .where(inArray(scormPackages.id, ids));
+
+    const courseIds = packages
+      .filter(({ entityType }) => entityType === "course")
+      .map(({ entityId }) => entityId);
+
+    const lessonIds = packages
+      .filter(({ entityType }) => entityType === "lesson")
+      .map(({ entityId }) => entityId);
+
+    const [courseNames, lessonNames] = await Promise.all([
+      courseIds.length
+        ? this.db
+            .select({
+              id: courses.id,
+              name: this.localizationService.getLocalizedSqlField(courses.title),
+            })
+            .from(courses)
+            .where(inArray(courses.id, courseIds))
+        : [],
+      lessonIds.length
+        ? this.db
+            .select({
+              id: lessons.id,
+              name: this.localizationService.getLocalizedSqlField(lessons.title),
+            })
+            .from(lessons)
+            .innerJoin(chapters, eq(chapters.id, lessons.chapterId))
+            .innerJoin(courses, eq(courses.id, chapters.courseId))
+            .where(inArray(lessons.id, lessonIds))
+        : [],
+    ]);
+
+    const entityNames = new Map([...courseNames, ...lessonNames].map(({ id, name }) => [id, name]));
+
+    return packages.map(({ id, entityId }) => ({ id, name: entityNames.get(entityId) ?? "" }));
+  }
+}

--- a/apps/api/src/activity-logs/activity-log-resource-name.types.ts
+++ b/apps/api/src/activity-logs/activity-log-resource-name.types.ts
@@ -1,0 +1,8 @@
+import type { ActivityLogResponse } from "./activity-logs.types";
+
+export type ActivityLogResourceReference = Pick<ActivityLogResponse, "resourceId" | "resourceType">;
+
+export type NamedActivityLogResource = {
+  id: string;
+  name: string;
+};

--- a/apps/api/src/activity-logs/activity-logs.module.ts
+++ b/apps/api/src/activity-logs/activity-logs.module.ts
@@ -4,7 +4,9 @@ import { CqrsModule } from "@nestjs/cqrs";
 import { ArticlesActivityHandler } from "src/activity-logs/handlers/articles-activity.handler";
 import { QAActivityHandler } from "src/activity-logs/handlers/qa-activity.handler";
 import { LiveTrainingModule } from "src/live-training/live-training.module";
+import { LocalizationModule } from "src/localization/localization.module";
 
+import { ActivityLogResourceNameService } from "./activity-log-resource-name.service";
 import { ActivityLogsController } from "./activity-logs.controller";
 import { ActivityLogsQueueService } from "./activity-logs.queue.service";
 import { ActivityLogsService } from "./activity-logs.service";
@@ -28,10 +30,11 @@ import { ActivityLogsWorker } from "./workers/activity-logs.worker";
 
 @Global()
 @Module({
-  imports: [CqrsModule, LiveTrainingModule],
+  imports: [CqrsModule, LiveTrainingModule, LocalizationModule],
   controllers: [ActivityLogsController],
   providers: [
     ActivityLogsService,
+    ActivityLogResourceNameService,
     ChapterActivityHandler,
     LessonActivityHandler,
     CourseActivityHandler,

--- a/apps/api/src/activity-logs/activity-logs.schema.ts
+++ b/apps/api/src/activity-logs/activity-logs.schema.ts
@@ -24,4 +24,9 @@ const baseActivityLogSchema = omitTenantId(
   }),
 );
 
-export const activityLogsListSchema = Type.Array(baseActivityLogSchema);
+export const activityLogsListSchema = Type.Array(
+  Type.Object({
+    ...baseActivityLogSchema.properties,
+    resourceName: Type.Union([Type.String(), Type.Null()]),
+  }),
+);

--- a/apps/api/src/activity-logs/activity-logs.service.spec.ts
+++ b/apps/api/src/activity-logs/activity-logs.service.spec.ts
@@ -15,11 +15,16 @@ describe("ActivityLogsService", () => {
     const queue = {
       enqueueActivityLog: jest.fn(),
     };
+    const resourceNameService = {
+      resolveCurrentResourceNames: jest.fn().mockResolvedValue(new Map()),
+      findResolvedResourceName: jest.fn().mockReturnValue(null),
+    };
 
     return {
       service: new ActivityLogsService(
         db as unknown as DatabasePg,
         queue as unknown as ConstructorParameters<typeof ActivityLogsService>[1],
+        resourceNameService as unknown as ConstructorParameters<typeof ActivityLogsService>[2],
       ),
       values,
     };

--- a/apps/api/src/activity-logs/activity-logs.service.ts
+++ b/apps/api/src/activity-logs/activity-logs.service.ts
@@ -20,7 +20,9 @@ import { dbAls } from "src/storage/db/db-als.store";
 import { activityLogs } from "src/storage/schema";
 import { settingsToJSONBuildObject } from "src/utils/settings-to-json-build-object";
 
+import { ActivityLogResourceNameService } from "./activity-log-resource-name.service";
 import { ActivityLogsQueueService } from "./activity-logs.queue.service";
+import { getActivityLogMetadataResourceName } from "./utils/get-activity-log-metadata-resource-name";
 
 import type {
   ActorType,
@@ -40,6 +42,7 @@ export class ActivityLogsService {
   constructor(
     @Inject("DB") private readonly db: DatabasePg,
     private readonly activityLogsQueueService: ActivityLogsQueueService,
+    private readonly activityLogResourceNameService: ActivityLogResourceNameService,
   ) {}
 
   async recordActivity(payload: RecordActivityLogParams): Promise<void> {
@@ -148,9 +151,36 @@ export class ActivityLogsService {
       .where(and(...conditions));
 
     const [data, [{ totalItems }]] = await Promise.all([logSearchQuery, countQuery]);
+    const metadataResourceNames = new Map(
+      data.map((activityLog) => [
+        activityLog.id,
+        getActivityLogMetadataResourceName(activityLog.metadata, activityLog.resourceType),
+      ]),
+    );
+
+    const unresolvedResources = data.filter(
+      (activityLog) =>
+        !metadataResourceNames.get(activityLog.id) &&
+        activityLog.resourceType &&
+        activityLog.resourceId,
+    );
+
+    const resolvedResourceNames =
+      await this.activityLogResourceNameService.resolveCurrentResourceNames(unresolvedResources);
+
+    const dataWithResourceNames = data.map((activityLog) => ({
+      ...activityLog,
+      resourceName:
+        metadataResourceNames.get(activityLog.id) ??
+        this.activityLogResourceNameService.findResolvedResourceName(
+          resolvedResourceNames,
+          activityLog.resourceType,
+          activityLog.resourceId,
+        ),
+    }));
 
     return {
-      data,
+      data: dataWithResourceNames,
       pagination: { totalItems, page, perPage },
     };
   }

--- a/apps/api/src/activity-logs/utils/get-activity-log-metadata-resource-name.spec.ts
+++ b/apps/api/src/activity-logs/utils/get-activity-log-metadata-resource-name.spec.ts
@@ -1,0 +1,59 @@
+import { ACTIVITY_LOG_RESOURCE_TYPES } from "@repo/shared";
+
+import { getActivityLogMetadataResourceName } from "./get-activity-log-metadata-resource-name";
+
+describe("getActivityLogMetadataResourceName", () => {
+  it("prefers the after snapshot over older and contextual course names", () => {
+    expect(
+      getActivityLogMetadataResourceName(
+        {
+          after: { title: "Updated course" },
+          before: { title: "Original course" },
+          context: { courseTitle: "Context course" },
+        },
+        ACTIVITY_LOG_RESOURCE_TYPES.COURSE,
+      ),
+    ).toBe("Updated course");
+  });
+
+  it("uses resource-specific deletion context", () => {
+    expect(
+      getActivityLogMetadataResourceName(
+        { context: { groupName: "Former group" } },
+        ACTIVITY_LOG_RESOURCE_TYPES.GROUP,
+      ),
+    ).toBe("Former group");
+  });
+
+  it.each([
+    [ACTIVITY_LOG_RESOURCE_TYPES.CHAPTER, "chapterName", "Removed chapter"],
+    [ACTIVITY_LOG_RESOURCE_TYPES.LESSON, "lessonName", "Removed lesson"],
+    [ACTIVITY_LOG_RESOURCE_TYPES.QA, "qaTitle", "Removed question"],
+  ])("uses the exact %s deletion field", (resourceType, field, name) => {
+    expect(getActivityLogMetadataResourceName({ context: { [field]: name } }, resourceType)).toBe(
+      name,
+    );
+  });
+
+  it("does not infer a name from an unrelated context field", () => {
+    expect(
+      getActivityLogMetadataResourceName(
+        { context: { lessonTitle: "Not persisted by the activity handler" } },
+        ACTIVITY_LOG_RESOURCE_TYPES.LESSON,
+      ),
+    ).toBeNull();
+  });
+
+  it("combines a user's event-time first and last names", () => {
+    expect(
+      getActivityLogMetadataResourceName(
+        { before: { firstName: "Ada", lastName: "Lovelace", email: "ada@example.com" } },
+        ACTIVITY_LOG_RESOURCE_TYPES.USER,
+      ),
+    ).toBe("Ada Lovelace");
+  });
+
+  it("returns null for metadata-free activity", () => {
+    expect(getActivityLogMetadataResourceName(null, ACTIVITY_LOG_RESOURCE_TYPES.COURSE)).toBeNull();
+  });
+});

--- a/apps/api/src/activity-logs/utils/get-activity-log-metadata-resource-name.ts
+++ b/apps/api/src/activity-logs/utils/get-activity-log-metadata-resource-name.ts
@@ -1,0 +1,66 @@
+import { ACTIVITY_LOG_RESOURCE_TYPES, type ActivityLogResourceType } from "@repo/shared";
+
+import { getStringProperty, isRecord } from "src/common/utils/object.utils";
+
+type ResourceNameFields = {
+  snapshot: string;
+  deletionContext?: string;
+};
+
+const resourceNameFields: Partial<Record<ActivityLogResourceType, ResourceNameFields>> = {
+  [ACTIVITY_LOG_RESOURCE_TYPES.COURSE]: { snapshot: "title", deletionContext: "courseTitle" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.CHAPTER]: { snapshot: "title", deletionContext: "chapterName" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.LESSON]: { snapshot: "title", deletionContext: "lessonName" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.ANNOUNCEMENT]: { snapshot: "title" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.GROUP]: { snapshot: "name", deletionContext: "groupName" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.CATEGORY]: { snapshot: "title", deletionContext: "categoryName" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.QA]: { snapshot: "title", deletionContext: "qaTitle" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.NEWS]: { snapshot: "title", deletionContext: "title" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE]: { snapshot: "title", deletionContext: "title" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.ARTICLE_SECTION]: { snapshot: "title", deletionContext: "title" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.LIVE_TRAINING]: { snapshot: "title", deletionContext: "title" },
+  [ACTIVITY_LOG_RESOURCE_TYPES.LEARNING_PATH]: { snapshot: "title" },
+};
+
+const getUserName = (snapshot: Record<string, unknown>) => {
+  const fullName = [
+    getStringProperty(snapshot, "firstName"),
+    getStringProperty(snapshot, "lastName"),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return fullName || getStringProperty(snapshot, "email");
+};
+
+export const getActivityLogMetadataResourceName = (
+  metadata: unknown,
+  resourceType: string | null,
+): string | null => {
+  if (!resourceType || !isRecord(metadata)) return null;
+
+  const snapshots = [metadata.after, metadata.before].filter(isRecord);
+  const context = isRecord(metadata.context) ? metadata.context : null;
+
+  if (resourceType === ACTIVITY_LOG_RESOURCE_TYPES.USER) {
+    for (const snapshot of snapshots) {
+      const name = getUserName(snapshot);
+      if (name) return name;
+    }
+
+    return context ? getStringProperty(context, "email") : null;
+  }
+
+  const fields = resourceNameFields[resourceType as ActivityLogResourceType];
+
+  if (!fields) return null;
+
+  for (const snapshot of snapshots) {
+    const name = getStringProperty(snapshot, fields.snapshot);
+    if (name) return name;
+  }
+
+  return context && fields.deletionContext
+    ? getStringProperty(context, fields.deletionContext)
+    : null;
+};

--- a/apps/api/src/common/utils/object.utils.ts
+++ b/apps/api/src/common/utils/object.utils.ts
@@ -1,0 +1,8 @@
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const getStringProperty = (record: Record<string, unknown>, key: string): string | null => {
+  const value = record[key];
+
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+};

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -55871,7 +55871,17 @@
                     }
                   ]
                 },
-                "metadata": {}
+                "metadata": {},
+                "resourceName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
               },
               "required": [
                 "id",
@@ -55883,7 +55893,8 @@
                 "actionType",
                 "resourceType",
                 "resourceId",
-                "metadata"
+                "metadata",
+                "resourceName"
               ]
             }
           },

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -8133,6 +8133,7 @@ export interface GetActivityLogsResponse {
     resourceType: (string | null) | null;
     resourceId: (string | null) | null;
     metadata: any;
+    resourceName: string | null;
   }[];
   pagination: {
     totalItems: number;

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -4209,10 +4209,13 @@
       "before": "Před",
       "after": "Po",
       "context": "Kontext",
+      "resourceName": "Název zdroje",
+      "resourceId": "ID zdroje",
       "noMetadata": "Žádná metadata nejsou k dispozici."
     },
     "fallbacks": {
       "unknown": "Neznámé",
+      "nameUnavailable": "Název není k dispozici",
       "notAvailable": "n/a"
     },
     "labels": {
@@ -4274,6 +4277,7 @@
       "email": "E-mail",
       "action": "Akce",
       "resource": "Zdroj",
+      "resourceName": "Název zdroje",
       "details": "Detaily",
       "showDetails": "Zobrazit detaily",
       "loading": "Načítání záznamů aktivit...",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -4207,10 +4207,13 @@
       "before": "Vorher",
       "after": "Nachher",
       "context": "Kontext",
+      "resourceName": "Ressourcenname",
+      "resourceId": "Ressourcen-ID",
       "noMetadata": "Keine Metadaten verfügbar."
     },
     "fallbacks": {
       "unknown": "Unbekannt",
+      "nameUnavailable": "Name nicht verfügbar",
       "notAvailable": "k. A."
     },
     "labels": {
@@ -4272,6 +4275,7 @@
       "email": "E-Mail",
       "action": "Aktion",
       "resource": "Ressource",
+      "resourceName": "Ressourcenname",
       "details": "Details",
       "showDetails": "Details anzeigen",
       "loading": "Aktivitätsprotokoll wird geladen...",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -4866,10 +4866,13 @@
       "before": "Before",
       "after": "After",
       "context": "Context",
+      "resourceName": "Resource name",
+      "resourceId": "Resource ID",
       "noMetadata": "No metadata available."
     },
     "fallbacks": {
       "unknown": "Unknown",
+      "nameUnavailable": "Name unavailable",
       "notAvailable": "n/a"
     },
     "labels": {
@@ -4931,6 +4934,7 @@
       "email": "Email",
       "action": "Action",
       "resource": "Resource",
+      "resourceName": "Resource name",
       "details": "Details",
       "showDetails": "Show details",
       "loading": "Loading activity logs...",

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -4852,10 +4852,13 @@
       "before": "Antes",
       "after": "Después",
       "context": "Contexto",
+      "resourceName": "Nombre del recurso",
+      "resourceId": "ID del recurso",
       "noMetadata": "No hay metadatos disponibles."
     },
     "fallbacks": {
       "unknown": "Desconocido",
+      "nameUnavailable": "Nombre no disponible",
       "notAvailable": "N/D"
     },
     "labels": {
@@ -4917,6 +4920,7 @@
       "email": "Correo electrónico",
       "action": "Acción",
       "resource": "Recurso",
+      "resourceName": "Nombre del recurso",
       "details": "Detalles",
       "showDetails": "Mostrar detalles",
       "loading": "Cargando registros de actividad...",

--- a/apps/web/app/locales/fr/translation.json
+++ b/apps/web/app/locales/fr/translation.json
@@ -4842,10 +4842,13 @@
       "before": "Avant",
       "after": "Après",
       "context": "Contexte",
+      "resourceName": "Nom de la ressource",
+      "resourceId": "ID de la ressource",
       "noMetadata": "Aucune métadonnée disponible."
     },
     "fallbacks": {
       "unknown": "Inconnu",
+      "nameUnavailable": "Nom indisponible",
       "notAvailable": "s/o"
     },
     "labels": {
@@ -4907,6 +4910,7 @@
       "email": "Adresse e-mail",
       "action": "Action",
       "resource": "Ressource",
+      "resourceName": "Nom de la ressource",
       "details": "Détails",
       "showDetails": "Afficher les détails",
       "loading": "Chargement des journaux d'activité...",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -4211,10 +4211,13 @@
       "before": "Prieš",
       "after": "Po",
       "context": "Kontekstas",
+      "resourceName": "Ištekliaus pavadinimas",
+      "resourceId": "Ištekliaus ID",
       "noMetadata": "Nėra galimų metaduomenų."
     },
     "fallbacks": {
       "unknown": "Nežinoma",
+      "nameUnavailable": "Pavadinimas nepasiekiamas",
       "notAvailable": "nėra"
     },
     "labels": {
@@ -4276,6 +4279,7 @@
       "email": "El. paštas",
       "action": "Veiksmas",
       "resource": "Išteklius",
+      "resourceName": "Ištekliaus pavadinimas",
       "details": "Išsamiai",
       "showDetails": "Rodyti detales",
       "loading": "Įkeliami veiklos žurnalai...",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -4905,10 +4905,13 @@
       "before": "Przed",
       "after": "Po",
       "context": "Kontekst",
+      "resourceName": "Nazwa zasobu",
+      "resourceId": "ID zasobu",
       "noMetadata": "Brak dostępnych metadanych."
     },
     "fallbacks": {
       "unknown": "Nieznane",
+      "nameUnavailable": "Nazwa niedostępna",
       "notAvailable": "b.d."
     },
     "labels": {
@@ -4970,6 +4973,7 @@
       "email": "E-mail",
       "action": "Akcja",
       "resource": "Zasób",
+      "resourceName": "Nazwa zasobu",
       "details": "Szczegóły",
       "showDetails": "Pokaż szczegóły",
       "loading": "Ładowanie dziennika zdarzeń...",

--- a/apps/web/app/modules/ActivityLogs/activityLogs.columns.test.tsx
+++ b/apps/web/app/modules/ActivityLogs/activityLogs.columns.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+import i18next from "~/utils/mocks/i18next.mock";
+
+import { getActivityLogsColumns } from "./activityLogs.columns";
+
+describe("getActivityLogsColumns", () => {
+  it("keeps the resource type and resource name in separate columns", () => {
+    const columns = getActivityLogsColumns(i18next.t, {
+      expandedRowId: null,
+      onToggleRow: vi.fn(),
+    });
+
+    expect(columns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "resource", header: "Resource" }),
+        expect.objectContaining({ accessorKey: "resourceName", header: "Resource name" }),
+      ]),
+    );
+  });
+});

--- a/apps/web/app/modules/ActivityLogs/activityLogs.columns.tsx
+++ b/apps/web/app/modules/ActivityLogs/activityLogs.columns.tsx
@@ -103,6 +103,18 @@ export const getActivityLogsColumns = (
     },
   },
   {
+    accessorKey: "resourceName",
+    header: t("activityLogsView.table.resourceName"),
+    cell: ({ row }) => (
+      <p className="max-w-64 truncate text-sm font-medium text-neutral-900">
+        {row.original.resourceName ??
+          (row.original.resourceId
+            ? t("activityLogsView.fallbacks.nameUnavailable")
+            : t("activityLogsView.fallbacks.notAvailable"))}
+      </p>
+    ),
+  },
+  {
     id: "action",
     header: t("activityLogsView.table.action"),
     cell: ({ row }) => {

--- a/apps/web/app/modules/ActivityLogs/components/ActivityLogAccordionRow.tsx
+++ b/apps/web/app/modules/ActivityLogs/components/ActivityLogAccordionRow.tsx
@@ -1,4 +1,5 @@
 import { flexRender, type Row } from "@tanstack/react-table";
+import { useTranslation } from "react-i18next";
 
 import { TableCell, TableRow } from "~/components/ui/table";
 import { cn } from "~/lib/utils";
@@ -18,6 +19,8 @@ export const ActivityLogAccordionRow = ({
   columnsLength,
   isExpanded,
 }: ActivityLogAccordionRowProps) => {
+  const { t } = useTranslation();
+
   return (
     <>
       <TableRow
@@ -36,6 +39,26 @@ export const ActivityLogAccordionRow = ({
         <TableRow id={`activity-log-details-${row.id}`} className="bg-neutral-50">
           <TableCell colSpan={columnsLength} className="px-0 py-0">
             <div className="border-t border-neutral-200 px-5 py-5">
+              {row.original.resourceId && (
+                <dl className="mb-4 grid gap-3 md:grid-cols-2">
+                  <div>
+                    <dt className="text-xs font-medium text-neutral-500">
+                      {t("activityLogsView.details.resourceName")}
+                    </dt>
+                    <dd className="mt-1 break-words text-sm text-neutral-900">
+                      {row.original.resourceName ?? t("activityLogsView.fallbacks.nameUnavailable")}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs font-medium text-neutral-500">
+                      {t("activityLogsView.details.resourceId")}
+                    </dt>
+                    <dd className="mt-1 break-all font-mono text-xs text-neutral-700">
+                      {row.original.resourceId}
+                    </dd>
+                  </div>
+                </dl>
+              )}
               <ActivityLogMetadata
                 metadata={row.original.metadata}
                 actionType={row.original.actionType}

--- a/apps/web/app/modules/ActivityLogs/components/ActivityLogMetadata.test.tsx
+++ b/apps/web/app/modules/ActivityLogs/components/ActivityLogMetadata.test.tsx
@@ -1,0 +1,80 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderWith } from "~/utils/testUtils";
+
+import { ActivityLogMetadata } from "./ActivityLogMetadata";
+
+describe("ActivityLogMetadata", () => {
+  it("renders metadata as flat label and value sections", () => {
+    renderWith().render(
+      <ActivityLogMetadata
+        metadata={{
+          before: { title: "Old title" },
+          after: { title: "New title" },
+          context: { language: "en" },
+        }}
+      />,
+    );
+
+    for (const label of ["Before", "After", "Context"]) {
+      const section = screen.getByText(label).parentElement;
+
+      expect(section).not.toHaveClass("border", "rounded-2xl", "bg-white");
+    }
+  });
+
+  it("removes only the outermost braces from metadata objects", () => {
+    const { container } = renderWith().render(
+      <ActivityLogMetadata
+        metadata={{
+          context: {
+            courseTitle: "Safety onboarding",
+            enrollment: { source: "admin" },
+          },
+        }}
+      />,
+    );
+    const metadata = container.querySelector("pre");
+
+    expect(metadata).toHaveTextContent('"courseTitle": "Safety onboarding"');
+    expect(metadata).toHaveTextContent('"enrollment": {');
+    expect(metadata?.textContent?.trim().startsWith("{")).toBe(false);
+    expect(metadata?.textContent?.trim().endsWith("}")).toBe(true);
+  });
+
+  it("aligns top-level properties after removing the outermost braces", () => {
+    const { container } = renderWith().render(
+      <ActivityLogMetadata
+        metadata={{
+          context: {
+            sentCount: "1",
+            skippedCount: "0",
+            recipientEmails: ["person@example.com"],
+          },
+        }}
+      />,
+    );
+
+    expect(container.querySelector("pre")?.textContent).toBe(
+      '"sentCount": "1",\n"skippedCount": "0",\n"recipientEmails": [\n  "person@example.com"\n]',
+    );
+  });
+
+  it("renders JSON-encoded object and array strings as structured metadata", () => {
+    const { container } = renderWith().render(
+      <ActivityLogMetadata
+        metadata={{
+          after: {
+            groups: '[{"id":"11111111-1111-4111-8111-111111111111","name":"Example group"}]',
+          },
+        }}
+      />,
+    );
+    const metadata = container.querySelector("pre");
+
+    expect(metadata).toHaveTextContent('"groups": [');
+    expect(metadata).toHaveTextContent('"name": "Example group"');
+    expect(metadata?.textContent).not.toContain('\\"');
+  });
+});

--- a/apps/web/app/modules/ActivityLogs/components/ActivityLogMetadata.tsx
+++ b/apps/web/app/modules/ActivityLogs/components/ActivityLogMetadata.tsx
@@ -5,11 +5,15 @@ import {
   type ActivityLogMetadataPayload,
   type ActivityLogActionType,
 } from "../activityLogs.utils";
+import { normalizeActivityLogMetadataValue } from "../utils/normalizeActivityLogMetadataValue";
 
 type ActivityLogMetadataProps = {
   metadata: ActivityLogMetadataPayload | null | undefined;
   actionType?: ActivityLogActionType | string | null;
 };
+
+const removeOutermostObjectBraces = (formattedValue: string) =>
+  formattedValue.slice(1, -1).trim().replace(/^ {2}/gm, "");
 
 const renderValue = (value: unknown) => {
   if (value === null || value === undefined) {
@@ -17,9 +21,17 @@ const renderValue = (value: unknown) => {
   }
 
   if (typeof value === "object") {
+    const normalizedValue = normalizeActivityLogMetadataValue(value);
+
+    const formattedValue = JSON.stringify(normalizedValue, null, 2);
+
+    const valueWithoutOutermostBraces = Array.isArray(normalizedValue)
+      ? formattedValue
+      : removeOutermostObjectBraces(formattedValue);
+
     return (
       <pre className="max-w-full overflow-x-auto rounded-2xl bg-neutral-950 px-4 py-3 text-xs leading-5 text-neutral-50">
-        {JSON.stringify(value, null, 2)}
+        {valueWithoutOutermostBraces || "-"}
       </pre>
     );
   }
@@ -38,8 +50,8 @@ export const ActivityLogMetadata = ({ metadata, actionType }: ActivityLogMetadat
   return (
     <dl className="grid gap-3 md:grid-cols-2">
       {sections.map((section) => (
-        <div key={section.key} className="rounded-2xl border border-neutral-200 bg-white px-4 py-3">
-          <dt className="text-[11px] font-semibold uppercase tracking-[0.16em] text-neutral-500">
+        <div key={section.key}>
+          <dt className="text-xs font-medium text-neutral-500">
             {t(`activityLogsView.details.${section.key}`)}
           </dt>
           <dd className="mt-1 text-sm leading-6 text-neutral-900">{renderValue(section.value)}</dd>

--- a/apps/web/app/modules/ActivityLogs/components/ActivityLogTimelineItem.test.tsx
+++ b/apps/web/app/modules/ActivityLogs/components/ActivityLogTimelineItem.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Accordion } from "~/components/ui/accordion";
+import { renderWith } from "~/utils/testUtils";
+
+import { ActivityLogTimelineItem } from "./ActivityLogTimelineItem";
+
+import type { ActivityLogItem } from "../activityLogs.utils";
+
+const activityLog: ActivityLogItem = {
+  id: "11111111-1111-4111-8111-111111111111",
+  createdAt: "2026-08-13T12:00:00.000Z",
+  updatedAt: "2026-08-13T12:00:00.000Z",
+  actorId: "22222222-2222-4222-8222-222222222222",
+  actorEmail: "admin@example.com",
+  actorRole: "admin",
+  actionType: "enroll_course",
+  resourceType: "course",
+  resourceId: "33333333-3333-4333-8333-333333333333",
+  resourceName: "Safety onboarding",
+  metadata: null,
+};
+
+const renderItem = (item: ActivityLogItem) =>
+  renderWith().render(
+    <Accordion type="single" value={item.id}>
+      <ActivityLogTimelineItem item={item} />
+    </Accordion>,
+  );
+
+describe("ActivityLogTimelineItem", () => {
+  it("shows the resolved resource name and ID for metadata-free activity", () => {
+    renderItem(activityLog);
+
+    expect(screen.getByText("Safety onboarding")).toBeVisible();
+    expect(screen.getByText(activityLog.resourceId as string)).toBeVisible();
+    expect(screen.getByText("No metadata available.")).toBeVisible();
+  });
+
+  it("shows the resource-name fallback when resolution fails", () => {
+    renderItem({ ...activityLog, resourceName: null });
+
+    expect(screen.getByText("Name unavailable")).toBeVisible();
+  });
+});

--- a/apps/web/app/modules/ActivityLogs/components/ActivityLogTimelineItem.tsx
+++ b/apps/web/app/modules/ActivityLogs/components/ActivityLogTimelineItem.tsx
@@ -1,6 +1,7 @@
 import { format } from "date-fns";
 import { ChevronDown } from "lucide-react";
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import { AccordionContent, AccordionItem, AccordionTrigger } from "~/components/ui/accordion";
 import { cn } from "~/lib/utils";
@@ -17,6 +18,7 @@ type ActivityLogTimelineItemProps = {
 };
 
 export const ActivityLogTimelineItem = ({ item }: ActivityLogTimelineItemProps) => {
+  const { t } = useTranslation();
   const createdAt = useMemo(() => new Date(item.createdAt), [item.createdAt]);
   const actionConfig = getActivityLogActionConfig(item.actionType);
   const ActionIcon = actionConfig.icon;
@@ -60,8 +62,18 @@ export const ActivityLogTimelineItem = ({ item }: ActivityLogTimelineItemProps) 
           <AccordionContent className="-mt-px px-0 pb-0 pt-0">
             <div className="rounded-b-[1.75rem] border border-t-0 border-neutral-200 bg-neutral-50 px-5 py-5">
               <div className="mb-4 text-sm text-neutral-500">
-                <span className="font-medium text-neutral-700">ID:</span>{" "}
-                <span className="text-neutral-900">{item.resourceId ?? "n/a"}</span>
+                <span className="font-medium text-neutral-700">
+                  {t("activityLogsView.details.resourceName")}:
+                </span>{" "}
+                <span className="text-neutral-900">
+                  {item.resourceName ?? t("activityLogsView.fallbacks.nameUnavailable")}
+                </span>
+                <span className="ml-4 font-medium text-neutral-700">
+                  {t("activityLogsView.details.resourceId")}:
+                </span>{" "}
+                <span className="text-neutral-900">
+                  {item.resourceId ?? t("activityLogsView.fallbacks.notAvailable")}
+                </span>
               </div>
 
               <ActivityLogMetadata metadata={item.metadata} />

--- a/apps/web/app/modules/ActivityLogs/utils/normalizeActivityLogMetadataValue.test.ts
+++ b/apps/web/app/modules/ActivityLogs/utils/normalizeActivityLogMetadataValue.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeActivityLogMetadataValue } from "./normalizeActivityLogMetadataValue";
+
+describe("normalizeActivityLogMetadataValue", () => {
+  it("recursively parses JSON-encoded objects and arrays", () => {
+    expect(
+      normalizeActivityLogMetadataValue({
+        groups: '[{"id":"11111111-1111-4111-8111-111111111111","name":"Example group"}]',
+      }),
+    ).toEqual({
+      groups: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          name: "Example group",
+        },
+      ],
+    });
+  });
+
+  it("keeps ordinary and malformed strings unchanged", () => {
+    expect(normalizeActivityLogMetadataValue("Example text")).toBe("Example text");
+    expect(normalizeActivityLogMetadataValue("{invalid JSON}")).toBe("{invalid JSON}");
+  });
+});

--- a/apps/web/app/modules/ActivityLogs/utils/normalizeActivityLogMetadataValue.ts
+++ b/apps/web/app/modules/ActivityLogs/utils/normalizeActivityLogMetadataValue.ts
@@ -1,0 +1,36 @@
+const isStructuredJsonString = (value: string) => {
+  const firstCharacter = value.at(0);
+  const lastCharacter = value.at(-1);
+
+  return (
+    (firstCharacter === "{" && lastCharacter === "}") ||
+    (firstCharacter === "[" && lastCharacter === "]")
+  );
+};
+
+export const normalizeActivityLogMetadataValue = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    const trimmedValue = value.trim();
+
+    if (!isStructuredJsonString(trimmedValue)) return value;
+
+    try {
+      return normalizeActivityLogMetadataValue(JSON.parse(trimmedValue));
+    } catch {
+      return value;
+    }
+  }
+
+  if (Array.isArray(value)) return value.map(normalizeActivityLogMetadataValue);
+
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        normalizeActivityLogMetadataValue(nestedValue),
+      ]),
+    );
+  }
+
+  return value;
+};

--- a/docs/specs/activity-logs-business-spec.md
+++ b/docs/specs/activity-logs-business-spec.md
@@ -6,7 +6,7 @@ Activity Logs give authorized administrators a searchable record of important ac
 
 For HR and L&D teams, this turns platform operations into an auditable timeline. When someone updates course content, changes users or groups, modifies settings, publishes an announcement, or completes a learning action, the organization has a place to inspect the history instead of relying on memory or manual notes.
 
-The main workflow is investigation: an admin opens Activity Logs, searches for a relevant actor, role, resource ID, or metadata value, narrows the list by action, resource, or date range, and expands a row to review the context behind a specific event.
+The main workflow is investigation: an admin opens Activity Logs, identifies the affected resource by its readable name and type, searches for a relevant actor, role, resource ID, or metadata value, narrows the list by action, resource, or date range, and expands a row to review the context behind a specific event.
 
 ## Who Uses It
 
@@ -22,6 +22,7 @@ The main workflow is investigation: an admin opens Activity Logs, searches for a
 - Filter activity to an exact resource type, such as course, lesson, user, group, announcement, live training, article, Q&A, settings, or integration activity; selecting a resource narrows the action filter to actions that can occur on that resource.
 - Narrow investigations to a date range.
 - Expand individual rows to inspect structured details such as changed fields, before/after values, and event context.
+- Identify affected courses, lessons, users, groups, and other named resources without interpreting internal IDs, including activity such as enrollments that has no additional metadata.
 - Track key platform events across authentication, users, groups, courses, lessons, chapters, announcements, settings, categories, Q&A, news, articles, live training, certificates, and integrations.
 - Record successful single-course and bulk-course deletions, including enough course context to investigate hard-deleted courses later.
 - Preserve actor identity, actor role, timestamp, action type, resource type, and resource reference where the source event provides it.
@@ -34,7 +35,9 @@ For compliance-oriented learning programs, the feature gives HR and L&D a tenant
 
 ## How It Works
 
-An administrator opens `/admin/activity-logs` from the admin navigation. Mentingo loads the latest logs in a table, lets the admin search across actor and event details, narrow the view by resource, one or more actions, or date, and provides pagination for longer histories. Selecting the details control expands a row so the admin can inspect the event metadata.
+An administrator opens `/admin/activity-logs` from the admin navigation. Mentingo loads the latest logs in a table, displays the resource type and readable resource name, lets the admin search across actor and event details, narrow the view by resource, one or more actions, or date, and provides pagination for longer histories. Selecting the details control expands a row so the admin can inspect the resource name and ID alongside any event metadata.
+
+For audit consistency, Mentingo prefers a name captured when the event happened. If the log does not contain one, it resolves the current tenant-scoped resource from the stored resource ID. If the resource no longer exists and no historical name was captured, the page clearly marks the name as unavailable while preserving the ID for investigation.
 
 The general search is intentionally broader than the older email-only filter: it can find values stored in the actor email, actor role, resource ID, and serialized event metadata. The backend still accepts the previous actor-email query parameter for compatibility, and when both the old email filter and the broader keyword search are present, both filters must match.
 
@@ -46,11 +49,12 @@ When supported domain events happen elsewhere in Mentingo, the activity-log hand
 - API endpoint is `GET /api/activity-logs` in `apps/api/src/activity-logs/activity-logs.controller.ts`.
 - Route and API access require `ACTIVITY_LOG_READ`.
 - `ActivityLogsService` supports pagination, backward-compatible actor-email filtering, broad keyword search, multi-value `actionTypes` filtering, exact `resourceType` filtering, and `from`/`to` date filters; `to` is handled as the end of the selected day.
+- Activity-log responses include a nullable `resourceName`, resolved in batches from event metadata first and current tenant-scoped resources second; settings, integrations, and unresolved resources have no name.
 - Activity-log action, resource, and resource-to-action mapping values are exposed from `packages/shared` so API validation and web filter options use the same contract.
 - Activity handlers under `apps/api/src/activity-logs/handlers` convert domain events into user-readable audit metadata, including the course deletion event emitted by the course service.
 
 ## Test Evidence
 
-API E2E coverage verifies paginated retrieval, date filtering including logs created on the selected `to` date, multi-action/resource filtering, broad keyword matching across actor email, resource ID, and metadata, and pagination totals with active filters. Broader activity-log E2E coverage verifies records for many source events such as course creation/update/deletion, lesson, chapter, enrollment, announcement, group, category, settings, environment, login, refresh, and logout activity.
+API E2E coverage verifies paginated retrieval, readable resource-name resolution for metadata-free course enrollment activity, event-time name precedence, date filtering including logs created on the selected `to` date, multi-action/resource filtering, broad keyword matching across actor email, resource ID, and metadata, and pagination totals with active filters. Broader activity-log E2E coverage verifies records for many source events such as course creation/update/deletion, lesson, chapter, enrollment, announcement, group, category, settings, environment, login, refresh, and logout activity.
 
-No dedicated frontend Activity Logs E2E spec was found; the page behavior is evidenced from the Activity Logs module implementation.
+Frontend component coverage verifies that metadata-free activity displays its resolved resource name and ID and that unresolved names use the translated fallback. No dedicated frontend Activity Logs E2E spec was found.


### PR DESCRIPTION
## Issue(s)

- #1853

## Overview

Adds readable resource names to Activity Logs while preserving the existing resource-type column and resource ID.

- Returns a nullable `resourceName` in activity-log API responses.
- Prefers the name captured in event metadata so historical logs keep the event-time value.
- Resolves missing names from current tenant-scoped resources in batches grouped by resource type, avoiding one query per activity-log row.
- Uses the localization service for localized resource fields and supports users, courses, chapters, lessons, announcements, groups, categories, Q&A, news, articles, article sections, live trainings, learning paths, and SCORM packages.
- Adds a dedicated resource-name table column and displays the resource name and ID in expanded row details.
- Simplifies the Before, After, and Context presentation by removing their outer cards and outermost object braces.
- Parses JSON-encoded metadata values recursively so arrays and objects are displayed without escaped JSON strings.
- Adds translated labels and fallbacks for all supported UI locales.

## Business Value

Administrators can identify the resource affected by an activity without interpreting an internal UUID. Historical names remain useful after a resource is renamed or deleted, while metadata-free events such as enrollments can still display the current resource name when it exists. This makes audit investigations faster and easier to understand.

## Screenshots / Video
<img width="2372" height="400" alt="Screenshot 2026-08-13 at 19 48 35 – ze zmianami" src="https://github.com/user-attachments/assets/ecb65796-17ce-46d8-8646-e9a2648380bd" />
