### PR TITLE
fix: prevent course progress in draft mode and restore the summary generation button

### DIFF
--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -1625,6 +1625,81 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
 
       expect(progress?.completedAt).toBeTruthy();
     });
+
+    it("rejects progress requests for draft courses", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "draft",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        courseId: course.id,
+        authorId: author.id,
+        lessonCount: 1,
+      });
+      const lesson = await createContentLesson(chapter.id);
+      await enableStudentMode(admin.id, course.id);
+
+      const response = await request(app.getHttpServer())
+        .post("/api/studentLessonProgress")
+        .query({ id: lesson.id, language: "en" })
+        .set("Cookie", cookies)
+        .expect(403);
+
+      expect(response.body.message).toBe("modernCourseView.draftCourseTooltip");
+
+      const progress = await db
+        .select()
+        .from(studentLessonProgress)
+        .where(
+          and(
+            eq(studentLessonProgress.studentId, admin.id),
+            eq(studentLessonProgress.lessonId, lesson.id),
+          ),
+        );
+
+      expect(progress).toHaveLength(0);
+    });
+
+    it("allows an admin to preview a draft lesson without learning mode", async () => {
+      const category = await categoryFactory.create();
+      const author = await userFactory.create({ role: SYSTEM_ROLE_SLUGS.CONTENT_CREATOR });
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const cookies = await cookieFor(admin, app);
+
+      const course = await courseFactory.create({
+        authorId: author.id,
+        categoryId: category.id,
+        status: "draft",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        courseId: course.id,
+        authorId: author.id,
+        lessonCount: 1,
+      });
+      const lesson = await createContentLesson(chapter.id);
+
+      await request(app.getHttpServer())
+        .get(`/api/lesson/${lesson.id}`)
+        .query({ language: "en" })
+        .set("Cookie", cookies)
+        .expect(200);
+    });
   });
 
   describe("POST /api/lesson/evaluation-quiz - quiz feedback redaction", () => {

--- a/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
+++ b/apps/api/src/studentLessonProgress/studentLessonProgress.service.ts
@@ -1,11 +1,12 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { COURSE_ENROLLMENT } from "@repo/shared";
+import { COURSE_ENROLLMENT, COURSE_STATUSES, PERMISSIONS, hasPermission } from "@repo/shared";
 import { and, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 
 import { CertificatesService } from "src/certificates/certificates.service";
@@ -41,6 +42,7 @@ import { PROGRESS_STATUSES } from "src/utils/types/progress.type";
 
 import {
   STUDENT_LESSON_PROGRESS_MESSAGE_KEYS,
+  type EnsureDraftCourseProgressAllowedParams,
   type LessonProgressAccessResult,
   type MarkLessonAsIncompleteParams,
   type MarkLessonProgressResult,
@@ -83,6 +85,13 @@ export class StudentLessonProgressService {
       userPermissions,
       dbInstance,
     );
+
+    this.ensureDraftCourseProgressAllowed({
+      courseStatus: accessCourseLessonWithDetails.courseStatus,
+      isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
+      isLearningModeActive,
+      userPermissions,
+    });
 
     const canTrackProgress = this.canUseLearnerProgressByPermissions(userPermissions, {
       hasEnrollment: Boolean(accessCourseLessonWithDetails.isAssigned),
@@ -128,6 +137,13 @@ export class StudentLessonProgressService {
       userPermissions,
       dbInstance,
     );
+
+    this.ensureDraftCourseProgressAllowed({
+      courseStatus: accessCourseLessonWithDetails.courseStatus,
+      isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
+      isLearningModeActive,
+      userPermissions,
+    });
 
     const canTrackProgress = this.canUseLearnerProgressByPermissions(userPermissions, {
       hasEnrollment: Boolean(accessCourseLessonWithDetails.isAssigned),
@@ -332,6 +348,13 @@ export class StudentLessonProgressService {
       dbInstance,
     );
 
+    this.ensureDraftCourseProgressAllowed({
+      courseStatus: accessCourseLessonWithDetails.courseStatus,
+      isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
+      isLearningModeActive,
+      userPermissions,
+    });
+
     const canTrackProgress = this.canUseLearnerProgressByPermissions(userPermissions, {
       hasEnrollment: Boolean(accessCourseLessonWithDetails.isAssigned),
       isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
@@ -422,6 +445,13 @@ export class StudentLessonProgressService {
       userPermissions,
       dbInstance,
     );
+
+    this.ensureDraftCourseProgressAllowed({
+      courseStatus: accessCourseLessonWithDetails.courseStatus,
+      isCourseAuthor: accessCourseLessonWithDetails.isCourseAuthor,
+      isLearningModeActive,
+      userPermissions,
+    });
 
     const canTrackProgress = this.canUseLearnerProgressByPermissions(userPermissions, {
       hasEnrollment: Boolean(accessCourseLessonWithDetails.isAssigned),
@@ -555,6 +585,22 @@ export class StudentLessonProgressService {
     access: { hasEnrollment: boolean; isCourseAuthor: boolean; isLearningModeActive: boolean },
   ) {
     return canTrackLessonProgress(userPermissions, access);
+  }
+
+  private ensureDraftCourseProgressAllowed({
+    courseStatus,
+    isCourseAuthor,
+    isLearningModeActive,
+    userPermissions,
+  }: EnsureDraftCourseProgressAllowedParams) {
+    if (courseStatus !== COURSE_STATUSES.DRAFT) return;
+
+    const canUpdateAllCourses = hasPermission(userPermissions, PERMISSIONS.COURSE_UPDATE);
+    const isPreviewingAsCourseManager = canUpdateAllCourses || isCourseAuthor;
+
+    if (isPreviewingAsCourseManager && !isLearningModeActive) return;
+
+    throw new ForbiddenException("modernCourseView.draftCourseTooltip");
   }
 
   private async isLessonStudentModeEnabled(
@@ -881,7 +927,7 @@ export class StudentLessonProgressService {
     userId: UUIDType,
     dbInstance: DatabasePg = this.db,
   ) {
-    return dbInstance
+    const [accessCourseLesson] = await dbInstance
       .select({
         isAssigned: sql<boolean>`CASE WHEN ${studentCourses.status} = ${COURSE_ENROLLMENT.ENROLLED} THEN TRUE ELSE FALSE END`,
         isFreemium: sql<boolean>`CASE WHEN ${chapters.isFreemium} THEN TRUE ELSE FALSE END`,
@@ -890,6 +936,7 @@ export class StudentLessonProgressService {
         lessonType: sql<LessonTypes>`${lessons.type}`,
         chapterId: sql<string>`${chapters.id}`,
         courseId: sql<string>`${chapters.courseId}`,
+        courseStatus: courses.status,
         isCourseAuthor: sql<boolean>`${courses.authorId} = ${userId}`,
       })
       .from(lessons)
@@ -908,6 +955,8 @@ export class StudentLessonProgressService {
         and(eq(studentCourses.courseId, chapters.courseId), eq(studentCourses.studentId, userId)),
       )
       .where(and(eq(lessons.id, id), isNull(users.deletedAt)));
+
+    return [accessCourseLesson];
   }
 
   async getUserCourseCompletionDetails(studentId: UUIDType, courseId: UUIDType) {

--- a/apps/api/src/studentLessonProgress/studentLessonProgress.type.ts
+++ b/apps/api/src/studentLessonProgress/studentLessonProgress.type.ts
@@ -1,4 +1,4 @@
-import type { PermissionKey } from "@repo/shared";
+import type { CourseStatus, PermissionKey } from "@repo/shared";
 import type { DatabasePg, UUIDType } from "src/common";
 import type { CurrentUserType } from "src/common/types/current-user.type";
 import type { LessonTypes } from "src/lesson/lesson.type";
@@ -23,6 +23,13 @@ export type MarkLessonAsIncompleteParams = {
 
 export type MarkLessonProgressResult = {
   messageKey: StudentLessonProgressMessageKey | null;
+};
+
+export type EnsureDraftCourseProgressAllowedParams = {
+  courseStatus: CourseStatus | null;
+  isCourseAuthor: boolean;
+  isLearningModeActive: boolean;
+  userPermissions: PermissionKey[];
 };
 
 export type LessonProgressAccessResult = {

--- a/apps/web/app/components/ui/tooltip.tsx
+++ b/apps/web/app/components/ui/tooltip.tsx
@@ -1,4 +1,5 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "~/lib/utils";
@@ -9,20 +10,35 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
+const tooltipContentVariants = cva(
+  "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+  {
+    variants: {
+      variant: {
+        default: "",
+        black: "max-w-xs rounded bg-black px-2 py-1 text-sm text-white shadow-md",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+type TooltipContentProps = React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> &
+  VariantProps<typeof tooltipContentVariants>;
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => {
+  TooltipContentProps
+>(({ className, sideOffset = 4, variant, ...props }, ref) => {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}
         data-state="instant-open"
-        className={cn(
-          "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          className,
-        )}
+        className={cn(tooltipContentVariants({ variant }), className)}
         {...props}
       />
     </TooltipPrimitive.Portal>

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -5557,6 +5557,7 @@
       "enter": "Spustit výukový režim",
       "exit": "Ukončit výukový režim"
     },
+    "draftCourseTooltip": "Tento kurz je ve stavu konceptu. Nemůžete se do něj zapsat ani pokračovat ve studiu.",
     "overview": {
       "courseSettings": "Nastavení kurzu",
       "manageCategories": "Spravovat kategorie",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -5549,6 +5549,7 @@
       "enter": "Lernmodus starten",
       "exit": "Lernmodus beenden"
     },
+    "draftCourseTooltip": "Dieser Kurs befindet sich im Entwurfsstatus. Sie können sich nicht anmelden oder weiter lernen.",
     "overview": {
       "courseSettings": "Kurseinstellungen",
       "manageCategories": "Kategorien verwalten",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -5575,6 +5575,7 @@
       "enter": "Enter learning mode",
       "exit": "Exit learning mode"
     },
+    "draftCourseTooltip": "This course is in draft status. You cannot enroll in it or continue learning.",
     "overview": {
       "courseSettings": "Course settings",
       "manageCategories": "Manage categories",

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -5513,6 +5513,7 @@
       "enter": "Entrar en modo aprendizaje",
       "exit": "Salir del modo aprendizaje"
     },
+    "draftCourseTooltip": "Este curso se encuentra en estado de borrador. No puedes inscribirte en él ni seguir aprendiendo.",
     "overview": {
       "courseSettings": "Configuración del curso",
       "manageCategories": "Gestionar categorías",

--- a/apps/web/app/locales/fr/translation.json
+++ b/apps/web/app/locales/fr/translation.json
@@ -5322,6 +5322,7 @@
       "enter": "Entrer en mode apprentissage",
       "exit": "Quitter le mode apprentissage"
     },
+    "draftCourseTooltip": "Ce cours est à l'état de brouillon. Vous ne pouvez pas vous y inscrire ni continuer à apprendre.",
     "overview": {
       "courseSettings": "Paramètres du cours",
       "manageCategories": "Gérer les catégories",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -5553,6 +5553,7 @@
       "enter": "Įjungti mokymosi režimą",
       "exit": "Išjungti mokymosi režimą"
     },
+    "draftCourseTooltip": "Šis kursas yra juodraščio būsenoje. Negalite jame užsiregistruoti ar tęsti mokymosi.",
     "overview": {
       "courseSettings": "Kurso nustatymai",
       "manageCategories": "Tvarkyti kategorijas",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -5612,6 +5612,7 @@
       "enter": "Włącz tryb nauki",
       "exit": "Wyjdź z trybu nauki"
     },
+    "draftCourseTooltip": "Kurs jest w wersji roboczej. Nie możesz się na niego zapisać ani kontynuować nauki.",
     "overview": {
       "courseSettings": "Ustawienia kursu",
       "manageCategories": "Zarządzaj kategoriami",

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.test.tsx
@@ -12,7 +12,7 @@ import CourseOverviewActions from "./CourseOverviewActions";
 const enrollCourse = vi.fn();
 let currentUser: { id: string } | undefined;
 let inviteOnlyRegistration = false;
-let course: { enrolled: boolean; id: string };
+let course: { enrolled: boolean; id: string; status: "draft" | "published" | "private" };
 let isAdminExperience = false;
 let canEditCourse = false;
 let isCourseStudentModeActive = false;
@@ -85,7 +85,7 @@ describe("CourseOverviewActions", () => {
     vi.clearAllMocks();
     currentUser = undefined;
     inviteOnlyRegistration = false;
-    course = { enrolled: false, id: "course-1" };
+    course = { enrolled: false, id: "course-1", status: "published" };
     isAdminExperience = false;
     canEditCourse = false;
     isCourseStudentModeActive = false;
@@ -125,11 +125,24 @@ describe("CourseOverviewActions", () => {
     expect(onToggleLearningMode).toHaveBeenCalledOnce();
   });
 
+  it("disables learning-mode entry for draft courses", async () => {
+    const onToggleLearningMode = vi.fn();
+    isAdminExperience = true;
+    course = { enrolled: false, id: "course-1", status: "draft" };
+
+    renderActions({ onToggleLearningMode });
+
+    expect(screen.getByTestId(COURSE_OVERVIEW_HANDLES.STUDENT_MODE_BUTTON)).toBeDisabled();
+    await userEvent.setup().click(screen.getByTestId(COURSE_OVERVIEW_HANDLES.STUDENT_MODE_BUTTON));
+
+    expect(onToggleLearningMode).not.toHaveBeenCalled();
+  });
+
   it("lets an enrolled learner continue learning", async () => {
     const user = userEvent.setup();
     const onContinueLearning = vi.fn();
     currentUser = { id: "user-1" };
-    course = { enrolled: true, id: "course-1" };
+    course = { enrolled: true, id: "course-1", status: "published" };
 
     renderActions({ onContinueLearning });
 
@@ -153,7 +166,7 @@ describe("CourseOverviewActions", () => {
 
   it("keeps course actions available on small screens", () => {
     currentUser = { id: "user-1" };
-    course = { enrolled: true, id: "course-1" };
+    course = { enrolled: true, id: "course-1", status: "published" };
 
     renderActions();
 

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverviewActions.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from "@remix-run/react";
+import { COURSE_STATUSES } from "@repo/shared";
 import { GraduationCap, Info, Play } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -13,6 +14,7 @@ import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
 import { topCoursesQueryOptions } from "~/api/queries/useTopCourses";
 import { queryClient } from "~/api/queryClient";
 import { Button } from "~/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 
 import { COURSE_OVERVIEW_HANDLES } from "../../../../../e2e/data/courses/handles";
@@ -42,6 +44,8 @@ export default function CourseOverviewActions({
   const { course, isAdminExperience, canEditCourse, isCourseStudentModeActive } =
     useCourseAccessProvider();
 
+  const isDraftCourse = course.status === COURSE_STATUSES.DRAFT;
+
   const handleEnrollCourse = async () => {
     await enrollCourse({ id: course.id });
     await Promise.all([
@@ -56,10 +60,10 @@ export default function CourseOverviewActions({
 
   const renderPrimaryAction = () => {
     if (isAdminExperience || (canEditCourse && isCourseStudentModeActive)) {
-      return (
+      const learningModeButton = (
         <Button
           data-testid={COURSE_OVERVIEW_HANDLES.STUDENT_MODE_BUTTON}
-          disabled={isTogglingLearningMode}
+          disabled={isTogglingLearningMode || (isDraftCourse && !isCourseStudentModeActive)}
           onClick={onToggleLearningMode}
           className="flex items-center gap-2 shadow-2xl transition disabled:opacity-50"
         >
@@ -74,6 +78,23 @@ export default function CourseOverviewActions({
           </span>
         </Button>
       );
+
+      if (isDraftCourse && !isCourseStudentModeActive) {
+        return (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>{learningModeButton}</span>
+              </TooltipTrigger>
+              <TooltipContent variant="black">
+                {t("modernCourseView.draftCourseTooltip")}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      }
+
+      return learningModeButton;
     }
 
     if (!course.enrolled) {

--- a/apps/web/app/modules/Courses/CourseView/CourseStatBar/CourseStatBar.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseStatBar/CourseStatBar.tsx
@@ -1,4 +1,4 @@
-import { PERMISSIONS } from "@repo/shared";
+import { COURSE_STATUSES, PERMISSIONS } from "@repo/shared";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useToggleCourseStudentMode } from "~/api/mutations";
@@ -232,6 +232,7 @@ export function CourseStatBar({ language }: CourseHeroProps) {
       <ProgressStatCard
         completedChapterCount={course.completedChapterCount ?? 0}
         courseChapterCount={course.courseChapterCount}
+        isDraftCourse={course.status === COURSE_STATUSES.DRAFT}
         isAdminExperience={isAdminExperience}
         onEnterLearningMode={enterLearningMode}
         timeLeftSeconds={timeLeftSeconds}

--- a/apps/web/app/modules/Courses/CourseView/CourseStatBar/ProgressStatCard.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseStatBar/ProgressStatCard.test.tsx
@@ -12,6 +12,7 @@ describe("ProgressStatCard", () => {
       <ProgressStatCard
         completedChapterCount={1}
         courseChapterCount={3}
+        isDraftCourse={false}
         isAdminExperience={false}
         onEnterLearningMode={vi.fn()}
         timeLeftSeconds={5_400}
@@ -30,6 +31,7 @@ describe("ProgressStatCard", () => {
       <ProgressStatCard
         completedChapterCount={3}
         courseChapterCount={3}
+        isDraftCourse={false}
         isAdminExperience={false}
         onEnterLearningMode={vi.fn()}
         timeLeftSeconds={0}
@@ -50,6 +52,7 @@ describe("ProgressStatCard", () => {
       <ProgressStatCard
         completedChapterCount={1}
         courseChapterCount={3}
+        isDraftCourse={false}
         isAdminExperience
         onEnterLearningMode={onEnterLearningMode}
         timeLeftSeconds={5_400}
@@ -61,5 +64,24 @@ describe("ProgressStatCard", () => {
     await user.click(screen.getByRole("button", { name: "Enter learning mode" }));
 
     expect(onEnterLearningMode).toHaveBeenCalledOnce();
+  });
+
+  it("does not let admins enter learning mode for draft courses", async () => {
+    const onEnterLearningMode = vi.fn();
+
+    renderWith().render(
+      <ProgressStatCard
+        completedChapterCount={1}
+        courseChapterCount={3}
+        isDraftCourse
+        isAdminExperience
+        onEnterLearningMode={onEnterLearningMode}
+        timeLeftSeconds={5_400}
+      />,
+    );
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Enter learning mode" }));
+
+    expect(onEnterLearningMode).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/modules/Courses/CourseView/CourseStatBar/ProgressStatCard.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseStatBar/ProgressStatCard.tsx
@@ -1,12 +1,15 @@
 import { Clock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+import { Button } from "~/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
 import { formatDuration } from "~/modules/Courses/utils/formatDuration";
 
 type ProgressStatCardProps = {
   completedChapterCount: number;
   courseChapterCount: number;
+  isDraftCourse: boolean;
   isAdminExperience: boolean;
   onEnterLearningMode: () => void;
   timeLeftSeconds: number;
@@ -15,6 +18,7 @@ type ProgressStatCardProps = {
 export default function ProgressStatCard({
   completedChapterCount,
   courseChapterCount,
+  isDraftCourse,
   isAdminExperience,
   onEnterLearningMode,
   timeLeftSeconds,
@@ -86,13 +90,36 @@ export default function ProgressStatCard({
       {isAdminExperience && (
         <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-neutral-950/35 opacity-0 backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100">
           <p className="mx-3 rounded-xl  bg-white/95 px-4 py-3 text-center text-sm font-semibold text-neutral-950 ">
-            <button
-              type="button"
-              onClick={onEnterLearningMode}
-              className="text-primary-700 underline transition-colors hover:text-primary-800"
-            >
-              {t("modernCourseView.learningMode.enter")}
-            </button>{" "}
+            {isDraftCourse ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        type="button"
+                        disabled
+                        variant="link"
+                        className="h-auto p-0 text-primary-700 underline"
+                      >
+                        {t("modernCourseView.learningMode.enter")}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent variant="black">
+                    {t("modernCourseView.draftCourseTooltip")}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <Button
+                type="button"
+                onClick={onEnterLearningMode}
+                variant="link"
+                className="h-auto p-0 text-primary-700 underline transition-colors hover:text-primary-800"
+              >
+                {t("modernCourseView.learningMode.enter")}
+              </Button>
+            )}
             {t("modernCourseView.stats.trackProgress")}
           </p>
         </div>

--- a/apps/web/app/modules/Dashboard/Home/HomeDashboard.page.tsx
+++ b/apps/web/app/modules/Dashboard/Home/HomeDashboard.page.tsx
@@ -1,5 +1,5 @@
-import { DASHBOARD_WIDGET_SIZES } from "@repo/shared";
-import { LayoutGrid, Settings2 } from "lucide-react";
+import { DASHBOARD_WIDGET_SIZES, PERMISSIONS, hasPermission } from "@repo/shared";
+import { Download, LayoutGrid, Loader2, Settings2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { P, match } from "ts-pattern";
@@ -23,6 +23,7 @@ import {
 } from "~/components/ui/alert-dialog";
 import { Button } from "~/components/ui/button";
 import Loader from "~/modules/common/Loader/Loader";
+import { useDownloadSummaryReport } from "~/modules/Statistics/Admin/hooks/useDownloadSummaryReport";
 import { setPageTitle } from "~/utils/setPageTitle";
 
 import { DashboardError } from "./components/DashboardError";
@@ -110,6 +111,9 @@ export default function HomeDashboardPage() {
   const { mutate: updateDashboardSettings } = useUpdateDashboardSettings();
   const { mutate: resetDashboardSettings, isPending: isRestoringDefault } =
     useResetDashboardSettings();
+  const { downloadReport, isDownloading } = useDownloadSummaryReport();
+
+  const canDownloadReport = hasPermission(currentUser?.permissions ?? [], PERMISSIONS.REPORT_READ);
 
   const visibleLayout = (isEditing ? draftWidgets : savedWidgets).filter(
     (widget) => widget.visible !== false,
@@ -164,9 +168,29 @@ export default function HomeDashboardPage() {
         <header className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
           <h1 className="h4">{t("dashboardHome.title")}</h1>
 
-          {!isError &&
-            (isEditing ? (
-              <div className="flex flex-wrap items-center gap-2">
+          {!isError && (
+            <div className="flex flex-wrap items-center gap-2">
+              {canDownloadReport && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  data-testid="dashboard-report-download"
+                  onClick={() => void downloadReport()}
+                  disabled={isDownloading}
+                >
+                  {isDownloading ? (
+                    <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Download className="mr-2 size-4" aria-hidden="true" />
+                  )}
+                  {t(
+                    isDownloading
+                      ? "adminStatisticsView.other.downloadingReport"
+                      : "adminStatisticsView.other.downloadReport",
+                  )}
+                </Button>
+              )}
+              {isEditing ? (
                 <div className="flex flex-wrap items-center gap-2">
                   <Button
                     type="button"
@@ -180,13 +204,14 @@ export default function HomeDashboardPage() {
                     {t("common.button.close")}
                   </Button>
                 </div>
-              </div>
-            ) : (
-              <Button type="button" onClick={handleStartEditing}>
-                <Settings2 className="mr-2 size-4" aria-hidden="true" />
-                {t("dashboardHome.customize")}
-              </Button>
-            ))}
+              ) : (
+                <Button type="button" onClick={handleStartEditing}>
+                  <Settings2 className="mr-2 size-4" aria-hidden="true" />
+                  {t("dashboardHome.customize")}
+                </Button>
+              )}
+            </div>
+          )}
         </header>
 
         <div>

--- a/apps/web/app/modules/Statistics/Admin/hooks/useDownloadSummaryReport.ts
+++ b/apps/web/app/modules/Statistics/Admin/hooks/useDownloadSummaryReport.ts
@@ -1,8 +1,15 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { ApiClient } from "~/api/api-client";
 import { useToast } from "~/components/ui/use-toast";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
+import {
+  extractFilenameFromContentDisposition,
+  triggerBrowserDownload,
+} from "~/utils/downloadFile";
+
+import type { AxiosResponse } from "axios";
 
 export function useDownloadSummaryReport() {
   const { toast } = useToast();
@@ -14,28 +21,16 @@ export function useDownloadSummaryReport() {
     setIsDownloading(true);
 
     try {
-      const baseUrl = import.meta.env.VITE_APP_URL || window.location.origin;
-      const response = await fetch(`${baseUrl}/api/report/summary?language=${language}`, {
-        method: "GET",
-        credentials: "include",
-      });
+      const response = (await ApiClient.api.reportControllerDownloadSummaryReport(
+        { language },
+        { format: "blob" },
+      )) as unknown as AxiosResponse<Blob>;
 
-      if (!response.ok) {
-        throw new Error("Failed to download report");
-      }
+      const filename =
+        extractFilenameFromContentDisposition(response.headers["content-disposition"]) ||
+        "summary-report.xlsx";
 
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const linkElement = document.createElement("a");
-      linkElement.href = url;
-
-      const today = new Date().toISOString().split("T")[0];
-      linkElement.download = `summary-report-${today}.xlsx`;
-
-      document.body.appendChild(linkElement);
-      linkElement.click();
-      document.body.removeChild(linkElement);
-      URL.revokeObjectURL(url);
+      triggerBrowserDownload(response.data, filename);
 
       toast({ description: t("adminStatisticsView.toast.reportDownloadSuccess") });
     } catch (error) {

--- a/apps/web/e2e/data/dashboard/handles.ts
+++ b/apps/web/e2e/data/dashboard/handles.ts
@@ -8,3 +8,7 @@ export const DASHBOARD_WIDGET_HANDLES = {
   STUDENT_CERTIFICATES: "dashboard-widget-student-certificates",
   TODO_TASKS: "dashboard-widget-todo-tasks",
 } as const;
+
+export const DASHBOARD_REPORT_HANDLES = {
+  DOWNLOAD: "dashboard-report-download",
+} as const;

--- a/apps/web/e2e/specs/dashboard/dashboard-report.spec.ts
+++ b/apps/web/e2e/specs/dashboard/dashboard-report.spec.ts
@@ -1,0 +1,33 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import { DASHBOARD_REPORT_HANDLES } from "../../data/dashboard/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openDashboardFlow } from "../../flows/dashboard/open-dashboard.flow";
+
+test("admin can download the summary report as an XLSX file", async ({ withReadonlyPage }) => {
+  await withReadonlyPage(USER_ROLE.admin, async ({ page }) => {
+    let reportRequestUrl = "";
+
+    await page.route("**/api/report/summary*", async (route) => {
+      reportRequestUrl = route.request().url();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers: {
+          "content-disposition": 'attachment; filename="summary-report-2026-08-21.xlsx"',
+        },
+        body: "fake-xlsx-content",
+      });
+    });
+
+    await openDashboardFlow(page);
+
+    const downloadButton = page.getByTestId(DASHBOARD_REPORT_HANDLES.DOWNLOAD);
+    await expect(downloadButton).toBeVisible();
+
+    const [download] = await Promise.all([page.waitForEvent("download"), downloadButton.click()]);
+
+    expect(new URL(reportRequestUrl).searchParams.get("language")).toBe("en");
+    expect(download.suggestedFilename()).toBe("summary-report-2026-08-21.xlsx");
+  });
+});

--- a/docs/specs/course-overview-management-business-spec.md
+++ b/docs/specs/course-overview-management-business-spec.md
@@ -22,6 +22,7 @@ Learners use the same overview to understand the course, continue learning, revi
 - Update inline course-overview edits immediately without making the user wait for a broad page refresh.
 - Manage curriculum through a dedicated action while keeping the legacy editor focused on curriculum.
 - Organize status, pricing, enrollment, sharing, and course behavior in a consistent tabbed settings sheet.
+- Keep draft courses in authoring mode by explaining that learning mode and progress tracking become available after publication.
 - Let eligible learners open a centered preview, download, and share an awarded certificate from the course page.
 - Keep mention suggestions usable with long participant names and near viewport edges.
 
@@ -31,7 +32,7 @@ Course teams spend less time navigating between management pages and see changes
 
 ## How It Works
 
-An administrator opens the course overview, selects a course language, and edits learner-facing details in place, or opens the settings sheet to choose a management area. The overview loads the selected course and language before showing the page, so users do not see a blank intermediate state. The selected language's learning outcomes can be edited independently, including clearing a translation without replacing the base-language content. Learners continue to see the base-language outcome fallback when a translated outcome is unavailable. Curriculum editing remains available through its dedicated action, and the course overview uses the established accordion curriculum with chapter counters, progress, access indicators, and lesson actions. The hero and course-details view remain usable on narrow screens. A learner who completes a certificate-enabled course sees a certificate card and can open the existing localized preview in a centered modal.
+An administrator opens the course overview, selects a course language, and edits learner-facing details in place, or opens the settings sheet to choose a management area. The overview loads the selected course and language before showing the page, so users do not see a blank intermediate state. The selected language's learning outcomes can be edited independently, including clearing a translation without replacing the base-language content. Learners continue to see the base-language outcome fallback when a translated outcome is unavailable. Curriculum editing remains available through its dedicated action, and the course overview uses the established accordion curriculum with chapter counters, progress, access indicators, and lesson actions. Draft courses keep users out of learning mode and explain that publication is required before learning progress can be recorded. The hero and course-details view remain usable on narrow screens. A learner who completes a certificate-enabled course sees a certificate card and can open the existing localized preview in a centered modal.
 
 ## Key Technical Context
 
@@ -42,6 +43,7 @@ An administrator opens the course overview, selects a course language, and edits
 - The mobile details view uses the shared bottom-sheet dialog behavior, while the hero grows with its content so controls remain accessible on narrow screens.
 - The settings sheet reuses established course-management panels and the course overview tab visual language.
 - Certificate visibility still depends on an issued certificate, completed course progress, and the effective learner experience.
+- The API rejects progress writes for draft courses, including progress initiated through lesson, video, SCORM, or AI mentor flows.
 - Course language remains explicit throughout localized management and certificate rendering.
 
 ## Verification Notes
@@ -49,3 +51,4 @@ An administrator opens the course overview, selects a course language, and edits
 - Source coverage exists for the modern overview, TOC tabs, settings drawer, details, outcomes, certificates, and discussions.
 - API coverage verifies localized course outcomes for editor and learner experiences, including empty translated outcomes.
 - Existing responsive course-overview E2E coverage verifies accessible controls and visible learner actions at a 320px viewport; additional loading-transition assertions remain a follow-up opportunity.
+- Focused web and API tests verify that draft-course learning-mode entry is disabled and draft progress writes are rejected without creating progress.

--- a/docs/specs/statistics-analytics-business-spec.md
+++ b/docs/specs/statistics-analytics-business-spec.md
@@ -35,7 +35,7 @@ Statistics and Analytics help learning teams move from anecdotal feedback to mea
 
 A learner opens Progress to see personal learning activity. Mentingo aggregates the learner's course, lesson, quiz, and streak data in the selected interface language and displays charts that help the learner continue from the right context.
 
-An administrator opens Analytics to review organization-level charts and download a summary report. These charts summarize course popularity, enrollment, completion, freemium conversion, and average quiz performance.
+An administrator opens the dashboard to review organization-level training completion and, when reporting access is granted, download the XLSX summary report. The report includes learner/course progress and quiz results within the administrator's permitted scope.
 
 From the course overview, permitted users can open the Statistics tab beside the table of contents. Mentingo reuses the full course-admin statistics experience there, showing overview metrics and detailed tables for learner progress, quiz results, AI mentor results, and learning time, with filters for groups, learners, quizzes, and mentor lessons.
 From a course management view, permitted users can open the Statistics tab. Mentingo shows course overview metrics and detailed tables for learner progress, quiz results, AI mentor results, and learning time, with filters for groups, learners, quizzes, and mentor lessons. Learner search accepts a given name, family name, or a combined full name so course managers can find a specific person using the name format they see in the table.


### PR DESCRIPTION
## Issue(s)
- #1907 
- #1923

## Overview

- Prevent learners from progressing through lessons while a course is still in draft mode.
- Restore the summary report download action on the dashboard for users with report access.
- Download reports through the generated API client and preserve the server-provided XLSX filename.
- Add frontend E2E coverage for the report button and download flow.
- Update the related course-overview and statistics business specifications.

## Business Value

Learners can no longer move through unfinished draft content accidentally, helping course authors control when training becomes available. Administrators regain the ability to export permitted learning data as an XLSX report, supporting operational follow-up, analysis, and reporting workflows.
