### PR TITLE
fix: ensure global search course progress is correctly displayed

### DIFF
--- a/apps/api/src/ai/mentor-configuration-generation/schemas/ai-mentor-configuration-generation.schema.ts
+++ b/apps/api/src/ai/mentor-configuration-generation/schemas/ai-mentor-configuration-generation.schema.ts
@@ -347,9 +347,7 @@ export type GeneratedAiMentorRoleplayConfigurationFields = Static<
 export type GeneratedAiMentorConfigurationFields =
   | GeneratedAiMentorTeacherConfigurationFields
   | GeneratedAiMentorRoleplayConfigurationFields;
-export type AiMentorGenerationLessonContext = Static<
-  typeof aiMentorGenerationLessonContextSchema
->;
+export type AiMentorGenerationLessonContext = Static<typeof aiMentorGenerationLessonContextSchema>;
 export type AiMentorConfigurationValidationIssue = Static<
   typeof aiMentorConfigurationValidationIssueSchema
 >;

--- a/apps/api/src/ai/mentor-configuration-generation/services/ai-mentor-configuration-generation-workflow.service.ts
+++ b/apps/api/src/ai/mentor-configuration-generation/services/ai-mentor-configuration-generation-workflow.service.ts
@@ -118,8 +118,7 @@ export class AiMentorConfigurationGenerationWorkflowService {
       options,
     );
 
-    const deterministicValidation =
-      getDeterministicAiMentorConfigurationValidation(latestDraft);
+    const deterministicValidation = getDeterministicAiMentorConfigurationValidation(latestDraft);
     const validation =
       deterministicValidation ??
       (await this.validatorService.validate({
@@ -143,10 +142,7 @@ export class AiMentorConfigurationGenerationWorkflowService {
         options,
       );
 
-    const nextHistory = [
-      ...attemptHistory,
-      { attempt, changes: changes ?? [], validation },
-    ];
+    const nextHistory = [...attemptHistory, { attempt, changes: changes ?? [], validation }];
 
     if (validation.passed)
       return this.report(
@@ -191,8 +187,7 @@ export class AiMentorConfigurationGenerationWorkflowService {
     input: RunAiMentorConfigurationGenerationInput,
   ): string | undefined {
     if (input.creatorInstruction) return input.creatorInstruction;
-    if (input.mode === AI_MENTOR_CONFIGURATION_GENERATION_MODE.IMPROVE)
-      return input.instruction;
+    if (input.mode === AI_MENTOR_CONFIGURATION_GENERATION_MODE.IMPROVE) return input.instruction;
     return undefined;
   }
 

--- a/apps/api/src/ai/mentor-configuration-generation/services/ai-mentor-configuration-generation-workflow.types.ts
+++ b/apps/api/src/ai/mentor-configuration-generation/services/ai-mentor-configuration-generation-workflow.types.ts
@@ -18,9 +18,7 @@ export type RunAiMentorConfigurationGenerationInput =
   | RepairAiMentorConfigurationDraftInput;
 
 export type AiMentorConfigurationGenerationWorkflowOptions = {
-  reportProgress?: (
-    progress: AiMentorConfigurationGenerationProgressEvent,
-  ) => Promise<void> | void;
+  reportProgress?: (progress: AiMentorConfigurationGenerationProgressEvent) => Promise<void> | void;
   isCancelled?: () => Promise<boolean> | boolean;
   onDraft?: (draft: AiMentorConfigurationContent) => Promise<void> | void;
   attempt?: number;

--- a/apps/api/src/ai/mentor-configuration-generation/services/ai-mentor-configuration-validator.service.spec.ts
+++ b/apps/api/src/ai/mentor-configuration-generation/services/ai-mentor-configuration-validator.service.spec.ts
@@ -39,9 +39,7 @@ describe("AiMentorConfigurationValidatorService", () => {
       getOpenAI: jest.fn().mockResolvedValue(jest.fn().mockReturnValue("MODEL")),
     };
 
-    return new AiMentorConfigurationValidatorService(
-      promptService as unknown as PromptService,
-    );
+    return new AiMentorConfigurationValidatorService(promptService as unknown as PromptService);
   };
 
   it("derives a pass from warnings and validates the current type-specific target", async () => {

--- a/apps/api/src/ai/mentor-configuration-generation/utils/ai-mentor-configuration-diff.ts
+++ b/apps/api/src/ai/mentor-configuration-generation/utils/ai-mentor-configuration-diff.ts
@@ -40,29 +40,27 @@ const getFieldValue = (
 ): string | null => {
   switch (field) {
     case "taskGoal":
-      return configuration.type === "teacher" ? configuration.taskGoal ?? null : null;
+      return configuration.type === "teacher" ? (configuration.taskGoal ?? null) : null;
     case "expertise":
-      return configuration.type === "teacher" ? configuration.expertise ?? null : null;
+      return configuration.type === "teacher" ? (configuration.expertise ?? null) : null;
     case "contentScope":
-      return configuration.type === "teacher" ? configuration.contentScope ?? null : null;
+      return configuration.type === "teacher" ? (configuration.contentScope ?? null) : null;
     case "teachingStyle":
-      return configuration.type === "teacher" ? configuration.teachingStyle ?? null : null;
+      return configuration.type === "teacher" ? (configuration.teachingStyle ?? null) : null;
     case "feedbackGuidance":
-      return configuration.type === "teacher" ? configuration.feedbackGuidance ?? null : null;
+      return configuration.type === "teacher" ? (configuration.feedbackGuidance ?? null) : null;
     case "scenario":
-      return configuration.type === "roleplay" ? configuration.scenario ?? null : null;
+      return configuration.type === "roleplay" ? (configuration.scenario ?? null) : null;
     case "aiRole":
-      return configuration.type === "roleplay" ? configuration.aiRole ?? null : null;
+      return configuration.type === "roleplay" ? (configuration.aiRole ?? null) : null;
     case "learnerRole":
-      return configuration.type === "roleplay" ? configuration.learnerRole ?? null : null;
+      return configuration.type === "roleplay" ? (configuration.learnerRole ?? null) : null;
     case "characterGoal":
-      return configuration.type === "roleplay" ? configuration.characterGoal ?? null : null;
+      return configuration.type === "roleplay" ? (configuration.characterGoal ?? null) : null;
     case "difficulty":
-      return configuration.type === "roleplay" ? configuration.difficulty ?? null : null;
+      return configuration.type === "roleplay" ? (configuration.difficulty ?? null) : null;
     case "factsAndConstraints":
-      return configuration.type === "roleplay"
-        ? configuration.factsAndConstraints ?? null
-        : null;
+      return configuration.type === "roleplay" ? (configuration.factsAndConstraints ?? null) : null;
     case "openingInstruction":
       return configuration.openingInstruction ?? null;
     case "additionalInstructions":
@@ -72,7 +70,6 @@ const getFieldValue = (
 
 const getChangeType = (before: string | null, after: string | null) => {
   if (before === null && after !== null) return AI_MENTOR_CONFIGURATION_DRAFT_CHANGE_TYPE.ADDED;
-  if (before !== null && after === null)
-    return AI_MENTOR_CONFIGURATION_DRAFT_CHANGE_TYPE.REMOVED;
+  if (before !== null && after === null) return AI_MENTOR_CONFIGURATION_DRAFT_CHANGE_TYPE.REMOVED;
   return AI_MENTOR_CONFIGURATION_DRAFT_CHANGE_TYPE.CHANGED;
 };

--- a/apps/api/src/ai/mentor-configuration-generation/utils/ai-mentor-configuration-draft.ts
+++ b/apps/api/src/ai/mentor-configuration-generation/utils/ai-mentor-configuration-draft.ts
@@ -128,9 +128,7 @@ export const getDeterministicAiMentorConfigurationValidation = (
     configuration.type === AI_MENTOR_TYPE.TEACHER &&
     typeof configuration.teachingStyle === "string" &&
     configuration.teachingStyle.trim().length > 0 &&
-    !Object.values(AI_MENTOR_TEACHING_STYLE).some(
-      (style) => style === configuration.teachingStyle,
-    )
+    !Object.values(AI_MENTOR_TEACHING_STYLE).some((style) => style === configuration.teachingStyle)
   )
     issues.push({
       code: "invalid_teaching_style",

--- a/apps/api/src/global-search/__tests__/global-search.controller.e2e-spec.ts
+++ b/apps/api/src/global-search/__tests__/global-search.controller.e2e-spec.ts
@@ -1,5 +1,12 @@
 import { faker } from "@faker-js/faker";
-import { ENTITY_TYPES, LESSON_TYPES, SUPPORTED_LANGUAGES, SYSTEM_ROLE_SLUGS } from "@repo/shared";
+import {
+  COURSE_ENROLLMENT,
+  ENTITY_TYPES,
+  LESSON_TYPES,
+  PROGRESS_STATUSES,
+  SUPPORTED_LANGUAGES,
+  SYSTEM_ROLE_SLUGS,
+} from "@repo/shared";
 import request from "supertest";
 
 import { buildJsonbField, buildJsonbFieldWithMultipleEntries } from "src/common/helpers/sqlHelpers";
@@ -11,7 +18,7 @@ import {
 } from "src/global-search/global-search.constants";
 import { SearchIndexService } from "src/global-search/search-index.service";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
-import { lessons, news, resourceEntity, resources } from "src/storage/schema";
+import { lessons, news, resourceEntity, resources, studentCourses } from "src/storage/schema";
 
 import { createE2ETest } from "../../../test/create-e2e-test";
 import { createCategoryFactory } from "../../../test/factory/category.factory";
@@ -120,6 +127,7 @@ describe("GlobalSearchController (e2e)", () => {
       "resources",
       "lessons",
       "chapters",
+      "student_courses",
       "courses",
       "news",
       "questions_and_answers",
@@ -139,6 +147,40 @@ describe("GlobalSearchController (e2e)", () => {
     const results = await search(cookie, "Searchable", SUPPORTED_LANGUAGES.EN);
 
     expect(results.categories).toEqual([expect.objectContaining({ id: category.id })]);
+  });
+
+  it("returns enrolled course progress in my course results", async () => {
+    const student = await userFactory.withCredentials({ password }).withUserSettings(db).create();
+    const author = await userFactory.create();
+    const course = await courseFactory.create({
+      authorId: author.id,
+      title: "Progress search course",
+      chapterCount: 3,
+    });
+
+    await db.insert(studentCourses).values({
+      studentId: student.id,
+      courseId: course.id,
+      progress: PROGRESS_STATUSES.IN_PROGRESS,
+      finishedChapterCount: 2,
+      status: COURSE_ENROLLMENT.ENROLLED,
+      tenantId: student.tenantId,
+    });
+    await searchIndexService.refreshCourse(course.id);
+
+    const results = await search(
+      cookieFor(student, app),
+      "Progress search",
+      SUPPORTED_LANGUAGES.EN,
+    );
+
+    expect(results.myCourses).toEqual([
+      expect.objectContaining({
+        id: course.id,
+        completedChapterCount: 2,
+        courseChapterCount: 3,
+      }),
+    ]);
   });
 
   it("uses requested-language search documents when they exist and match", async () => {

--- a/apps/api/src/global-search/__tests__/global-search.controller.e2e-spec.ts
+++ b/apps/api/src/global-search/__tests__/global-search.controller.e2e-spec.ts
@@ -3,7 +3,6 @@ import {
   COURSE_ENROLLMENT,
   ENTITY_TYPES,
   LESSON_TYPES,
-  PROGRESS_STATUSES,
   SUPPORTED_LANGUAGES,
   SYSTEM_ROLE_SLUGS,
 } from "@repo/shared";
@@ -19,6 +18,7 @@ import {
 import { SearchIndexService } from "src/global-search/search-index.service";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
 import { lessons, news, resourceEntity, resources, studentCourses } from "src/storage/schema";
+import { PROGRESS_STATUSES } from "src/utils/types/progress.type";
 
 import { createE2ETest } from "../../../test/create-e2e-test";
 import { createCategoryFactory } from "../../../test/factory/category.factory";
@@ -169,7 +169,7 @@ describe("GlobalSearchController (e2e)", () => {
     await searchIndexService.refreshCourse(course.id);
 
     const results = await search(
-      cookieFor(student, app),
+      await cookieFor(student, app),
       "Progress search",
       SUPPORTED_LANGUAGES.EN,
     );

--- a/apps/api/src/global-search/global-search.repository.ts
+++ b/apps/api/src/global-search/global-search.repository.ts
@@ -96,7 +96,9 @@ export class GlobalSearchRepository {
         ),
         thumbnailUrl: courses.thumbnailS3Key,
         courseChapterCount: courses.chapterCount,
-        completedChapterCount: sql<number>`0`,
+        completedChapterCount: options.enrolledStudentId
+          ? sql<number>`COALESCE(${studentCourses.finishedChapterCount}, 0)`
+          : sql<number>`0`,
       })
       .from(courses)
       .innerJoin(categories, eq(categories.id, courses.categoryId))

--- a/apps/api/src/lesson/ai-mentor-configuration/controllers/ai-mentor-configuration-generation.controller.spec.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/controllers/ai-mentor-configuration-generation.controller.spec.ts
@@ -60,10 +60,7 @@ describe("AiMentorConfigurationGenerationController", () => {
 
   it("requires either course update permission at the HTTP boundary", () => {
     expect(
-      Reflect.getMetadata(
-        REQUIRED_PERMISSIONS_KEY,
-        AiMentorConfigurationGenerationController,
-      ),
+      Reflect.getMetadata(REQUIRED_PERMISSIONS_KEY, AiMentorConfigurationGenerationController),
     ).toEqual([PERMISSIONS.COURSE_UPDATE, PERMISSIONS.COURSE_UPDATE_OWN]);
   });
 
@@ -77,9 +74,9 @@ describe("AiMentorConfigurationGenerationController", () => {
       brief: "Create a discovery coach.",
     } as const;
 
-    await expect(
-      controller.generateAiMentorConfiguration(input, currentUser),
-    ).resolves.toEqual({ data: { generationId } });
+    await expect(controller.generateAiMentorConfiguration(input, currentUser)).resolves.toEqual({
+      data: { generationId },
+    });
     expect(queueService.start).toHaveBeenCalledWith(input, currentUser);
   });
 
@@ -104,9 +101,7 @@ describe("AiMentorConfigurationGenerationController", () => {
     await controller.generateAiMentorConfiguration(input, currentUser);
 
     expect(queueService.start).toHaveBeenCalledWith(input, currentUser);
-    expect(queueService.start.mock.calls[0][0].currentConfiguration).toBe(
-      currentConfiguration,
-    );
+    expect(queueService.start.mock.calls[0][0].currentConfiguration).toBe(currentConfiguration);
   });
 
   it("passes the current unsaved draft to non-mutating validation", async () => {

--- a/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation-queue.service.spec.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation-queue.service.spec.ts
@@ -157,12 +157,8 @@ describe("AiMentorConfigurationGenerationQueueService", () => {
     await expect(service.getSnapshot(generationId, actor)).rejects.toBeInstanceOf(
       NotFoundException,
     );
-    await expect(service.revise(generationId, actor)).rejects.toBeInstanceOf(
-      NotFoundException,
-    );
-    await expect(service.cancel(generationId, actor)).rejects.toBeInstanceOf(
-      NotFoundException,
-    );
+    await expect(service.revise(generationId, actor)).rejects.toBeInstanceOf(NotFoundException);
+    await expect(service.cancel(generationId, actor)).rejects.toBeInstanceOf(NotFoundException);
     expect(generationService.prepareRevision).not.toHaveBeenCalled();
     expect(job.updateData).not.toHaveBeenCalled();
   });

--- a/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation-queue.service.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation-queue.service.ts
@@ -70,10 +70,7 @@ export class AiMentorConfigurationGenerationQueueService {
       progress.validation,
       progress.attemptHistory,
     );
-    const revisionGenerationId = uuidv5(
-      `revision-${prepared.attempt}`,
-      generationId,
-    );
+    const revisionGenerationId = uuidv5(`revision-${prepared.attempt}`, generationId);
 
     return this.enqueue(prepared, currentUser, revisionGenerationId);
   }
@@ -192,9 +189,7 @@ export class AiMentorConfigurationGenerationQueueService {
   }
 
   private getQueue() {
-    return this.globalQueueService.getQueue(
-      QUEUE_NAMES.AI_MENTOR_CONFIGURATION_GENERATION,
-    );
+    return this.globalQueueService.getQueue(QUEUE_NAMES.AI_MENTOR_CONFIGURATION_GENERATION);
   }
 
   private getStoredProgress(
@@ -205,10 +200,7 @@ export class AiMentorConfigurationGenerationQueueService {
       return undefined;
 
     const latestDraft = "latestDraft" in value ? value.latestDraft : undefined;
-    if (
-      latestDraft !== undefined &&
-      Value.Check(aiMentorConfigurationContentSchema, latestDraft)
-    )
+    if (latestDraft !== undefined && Value.Check(aiMentorConfigurationContentSchema, latestDraft))
       return { progress: value.progress, latestDraft };
 
     return { progress: value.progress };

--- a/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.constants.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.constants.ts
@@ -1,5 +1,4 @@
-export const AI_MENTOR_CONFIGURATION_GENERATION_JOB_NAME =
-  "ai-mentor-configuration-generation";
+export const AI_MENTOR_CONFIGURATION_GENERATION_JOB_NAME = "ai-mentor-configuration-generation";
 
 export const AI_MENTOR_CONFIGURATION_GENERATION_JOB_RETENTION = {
   age: 60 * 60,

--- a/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.service.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.service.ts
@@ -93,8 +93,9 @@ export class AiMentorConfigurationGenerationService {
       input.lessonId,
       currentUser,
     );
-    const deterministicValidation =
-      getDeterministicAiMentorConfigurationValidation(input.configuration);
+    const deterministicValidation = getDeterministicAiMentorConfigurationValidation(
+      input.configuration,
+    );
     if (deterministicValidation) return deterministicValidation;
 
     if (!Value.Check(aiMentorConfigurationContentSchema, input.configuration))

--- a/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.types.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.types.ts
@@ -15,9 +15,7 @@ export type PreparedAiMentorConfigurationGeneration = {
 };
 
 export type AiMentorConfigurationGenerationExecutionOptions = {
-  reportProgress?: (
-    progress: AiMentorConfigurationGenerationProgressEvent,
-  ) => Promise<void> | void;
+  reportProgress?: (progress: AiMentorConfigurationGenerationProgressEvent) => Promise<void> | void;
   isCancelled?: () => Promise<boolean> | boolean;
   onDraft?: (draft: AiMentorConfigurationContent) => Promise<void> | void;
 };
@@ -34,7 +32,5 @@ export type AiMentorConfigurationGenerationStoredProgress = {
   latestDraft?: AiMentorConfigurationContent;
 };
 
-export type GenerateAiMentorConfigurationApplicationInput =
-  GenerateAiMentorConfigurationInput;
-export type GenerateAiMentorConfigurationApplicationResult =
-  AiMentorConfigurationGenerationResult;
+export type GenerateAiMentorConfigurationApplicationInput = GenerateAiMentorConfigurationInput;
+export type GenerateAiMentorConfigurationApplicationResult = AiMentorConfigurationGenerationResult;

--- a/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.worker.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/generation/ai-mentor-configuration-generation.worker.ts
@@ -45,13 +45,9 @@ export class AiMentorConfigurationGenerationWorker implements OnModuleDestroy {
 
   private async handleJob(job: Job<AiMentorConfigurationGenerationJobData>) {
     if (job.name !== AI_MENTOR_CONFIGURATION_GENERATION_JOB_NAME)
-      throw new Error(
-        `Unexpected AI Mentor configuration generation job name: ${job.name}`,
-      );
+      throw new Error(`Unexpected AI Mentor configuration generation job name: ${job.name}`);
 
-    return this.tenantDbRunnerService.runWithTenant(job.data.tenantId, () =>
-      this.process(job),
-    );
+    return this.tenantDbRunnerService.runWithTenant(job.data.tenantId, () => this.process(job));
   }
 
   private async process(job: Job<AiMentorConfigurationGenerationJobData>) {

--- a/apps/api/src/lesson/ai-mentor-configuration/services/ai-mentor-configuration.service.spec.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/services/ai-mentor-configuration.service.spec.ts
@@ -65,12 +65,8 @@ describe("AiMentorConfigurationService generation authoring gate", () => {
   };
 
   it("authorizes a new unsaved lesson at course scope", async () => {
-    const {
-      adminLessonService,
-      courseFeaturePolicyService,
-      masterCourseService,
-      service,
-    } = createService();
+    const { adminLessonService, courseFeaturePolicyService, masterCourseService, service } =
+      createService();
 
     await expect(
       service.prepareGenerationAuthoringContext(courseId, undefined, currentUser),
@@ -88,12 +84,8 @@ describe("AiMentorConfigurationService generation authoring gate", () => {
   });
 
   it("authorizes an existing AI Mentor lesson at lesson scope", async () => {
-    const {
-      adminLessonService,
-      courseFeaturePolicyService,
-      masterCourseService,
-      service,
-    } = createService();
+    const { adminLessonService, courseFeaturePolicyService, masterCourseService, service } =
+      createService();
 
     await expect(
       service.prepareGenerationAuthoringContext(courseId, lessonId, currentUser),
@@ -101,9 +93,10 @@ describe("AiMentorConfigurationService generation authoring gate", () => {
     expect(masterCourseService.assertCourseContentEditableByLessonId).toHaveBeenCalledWith(
       lessonId,
     );
-    expect(
-      courseFeaturePolicyService.assertCourseFeatureEnabledByLessonId,
-    ).toHaveBeenCalledWith(lessonId, COURSE_FEATURE.CURRICULUM_EDITING);
+    expect(courseFeaturePolicyService.assertCourseFeatureEnabledByLessonId).toHaveBeenCalledWith(
+      lessonId,
+      COURSE_FEATURE.CURRICULUM_EDITING,
+    );
     expect(adminLessonService.validateAccess).toHaveBeenCalledWith(
       ENTITY_TYPES.LESSON,
       currentUser,

--- a/apps/api/src/lesson/ai-mentor-configuration/types/ai-mentor-configuration.types.ts
+++ b/apps/api/src/lesson/ai-mentor-configuration/types/ai-mentor-configuration.types.ts
@@ -32,10 +32,7 @@ export type ConfiguredAiMentorLessonContext = Omit<
   configurationType: AiMentorType;
 };
 
-export type AiMentorLessonContext = Omit<
-  AiMentorConfigurationLessonContext,
-  "aiMentorLessonId"
-> & {
+export type AiMentorLessonContext = Omit<AiMentorConfigurationLessonContext, "aiMentorLessonId"> & {
   aiMentorLessonId: UUIDType;
 };
 

--- a/apps/web/app/components/Navigation/GlobalSearch/CourseEntry.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/CourseEntry.tsx
@@ -1,7 +1,4 @@
 import { Link } from "@remix-run/react";
-import { PERMISSIONS } from "@repo/shared";
-
-import { usePermissions } from "../../../hooks/usePermissions";
 
 import type { SearchResponse } from "~/api/generated-api";
 
@@ -12,13 +9,9 @@ export const CourseEntry = ({
   item: SearchResponse["data"]["allCourses"][number];
   onSelect: () => void;
 }) => {
-  const { hasAccess: canUpdateLearningProgress } = usePermissions({
-    required: PERMISSIONS.LEARNING_PROGRESS_UPDATE,
-  });
-
   return (
     <Link
-      to={canUpdateLearningProgress ? `/course/${item.id}` : `/admin/beta-courses/${item.id}`}
+      to={`/course/${item.id}`}
       onClick={onSelect}
       className="group focus:outline-none focus-visible:outline-none"
     >

--- a/apps/web/app/components/Navigation/GlobalSearch/MyCourseEntry.tsx
+++ b/apps/web/app/components/Navigation/GlobalSearch/MyCourseEntry.tsx
@@ -1,8 +1,6 @@
 import { Link } from "@remix-run/react";
-import { PERMISSIONS } from "@repo/shared";
 
 import { SegmentedRing } from "~/assets/svgs";
-import { usePermissions } from "~/hooks/usePermissions";
 
 import type { SearchResponse } from "~/api/generated-api";
 
@@ -13,15 +11,12 @@ export const MyCourseEntry = ({
   item: SearchResponse["data"]["myCourses"][number];
   onSelect: () => void;
 }) => {
-  const { hasAccess: canUpdateLearningProgress } = usePermissions({
-    required: PERMISSIONS.LEARNING_PROGRESS_UPDATE,
-  });
   const courseChapterCount = item.courseChapterCount ?? 0;
   const completedChapterCount = item.completedChapterCount ?? 0;
 
   return (
     <Link
-      to={canUpdateLearningProgress ? `/course/${item.id}` : `/admin/beta-courses/${item.id}`}
+      to={`/course/${item.id}`}
       onClick={onSelect}
       className="group focus:outline-none focus-visible:outline-none"
     >

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorGeneration/aiMentorGeneration.types.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorGeneration/aiMentorGeneration.types.ts
@@ -18,8 +18,7 @@ export const AI_MENTOR_GENERATION_MODE = {
 export type AiMentorGenerationMode =
   (typeof AI_MENTOR_GENERATION_MODE)[keyof typeof AI_MENTOR_GENERATION_MODE];
 
-export const AI_MENTOR_GENERATION_STATUS =
-  AI_MENTOR_CONFIGURATION_GENERATION_STATUS;
+export const AI_MENTOR_GENERATION_STATUS = AI_MENTOR_CONFIGURATION_GENERATION_STATUS;
 
 export type AiMentorGenerationStatus =
   (typeof AI_MENTOR_GENERATION_STATUS)[keyof typeof AI_MENTOR_GENERATION_STATUS];
@@ -73,6 +72,5 @@ export type AiMentorGenerationViewState = {
   error?: string;
 };
 
-export type AiMentorGenerationSnapshot =
-  GetAiMentorConfigurationGenerationResponse["data"];
+export type AiMentorGenerationSnapshot = GetAiMentorConfigurationGenerationResponse["data"];
 export type AiMentorValidationResult = ValidateAiMentorConfigurationDraftResponse["data"];

--- a/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorGeneration/useAiMentorConfigurationGeneration.ts
+++ b/apps/web/app/modules/Admin/EditCourse/CourseLessons/NewLesson/AiMentorLessonForm/AiMentorGeneration/useAiMentorConfigurationGeneration.ts
@@ -25,9 +25,7 @@ import type {
 import type { AiMentorType } from "@repo/shared";
 import type { GenerateAiMentorConfigurationBody } from "~/api/generated-api";
 
-const getRequestedConfigurationType = (
-  input: GenerateAiMentorConfigurationBody,
-): AiMentorType =>
+const getRequestedConfigurationType = (input: GenerateAiMentorConfigurationBody): AiMentorType =>
   input.mode === AI_MENTOR_CONFIGURATION_GENERATION_MODE.CREATE
     ? input.configurationType
     : input.currentConfiguration.type;
@@ -85,8 +83,7 @@ export const useAiMentorConfigurationGeneration = () => {
   const startGeneration = async (input: GenerateAiMentorConfigurationBody) => {
     const requestedType = getRequestedConfigurationType(input);
     setGenerationType(requestedType);
-    const { generationId: nextGenerationId } =
-      await startAiMentorConfigurationGeneration(input);
+    const { generationId: nextGenerationId } = await startAiMentorConfigurationGeneration(input);
     const initialSnapshot: AiMentorGenerationSnapshot = {
       generationId: nextGenerationId,
       progress: {

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -75,15 +75,15 @@ export const clientLoader = async ({
     throw redirect(buildCourseRedirectPath(request.url, slug), 302);
   }
 
-  await queryClient.ensureQueryData(courseQueryOptions(idOrSlug, language)).catch(
-    (error: unknown) => {
+  await queryClient
+    .ensureQueryData(courseQueryOptions(idOrSlug, language))
+    .catch((error: unknown) => {
       if (isAxiosError(error) && error.response?.status === 404) {
         throw redirect("/courses", 302);
       }
 
       throw error;
-    },
-  );
+    });
 
   return null;
 };

--- a/docs/specs/global-search-business-spec.md
+++ b/docs/specs/global-search-business-spec.md
@@ -22,6 +22,7 @@ The main workflow is direct: a user opens search from the navigation or keyboard
 - Respect the signed-in user's permissions so each user only sees result categories they are allowed to access.
 - Search every indexed language for learning and knowledge content so multilingual materials remain discoverable.
 - Show matched lesson attachment filenames when the search term matches an attached resource.
+- Show a learner's completed-chapter progress beside assigned course results.
 - Support keyboard opening, navigation, and selection for faster repeated use.
 
 ## End-User Value
@@ -32,11 +33,13 @@ The language-aware behavior improves multilingual delivery: users can search fro
 
 ## How It Works
 
-Users open the search dialog from the navigation, enter a term, and Mentingo requests matching results for the current interface language. Results are grouped by content type, and selecting a result takes the user to the relevant course, lesson, article, user, or administration area.
+Users open the search dialog from the navigation, enter a term, and Mentingo requests matching results for the current interface language. Results are grouped by content type, and selecting a result takes the user to the relevant course overview, lesson, article, user, or administration area.
 
 For indexed learning and knowledge content, Mentingo searches all language-specific documents attached to each item. The displayed title and category still use the user's selected interface language where those fields are localized, but a result can be found because its Polish, English, or other indexed text matched the query.
 
 Search visibility remains permission-aware. For example, users without user-management permissions do not receive user results, and course/lesson results follow the existing course access distinctions.
+
+When learners find an assigned course, the result includes the same completed-chapter count used by their course list, so the search result accurately reflects where they are in the course.
 
 ## Key Technical Context
 
@@ -45,9 +48,11 @@ Search visibility remains permission-aware. For example, users without user-mana
 - Indexed search documents live in the `search_documents` table and are refreshed by `SearchIndexService`.
 - Indexed content matching is language-inclusive: `search_documents` rows from every stored language can match, and the repository tracks which languages matched each result.
 - Permissions are enforced by the global-search endpoint and service-level result category checks.
+- Assigned-course progress is read from the learner's enrolled course record and is not shown for administrative or generally available course result groups.
 
 ## Test Evidence
 
 - API E2E coverage verifies requested-language search, non-requested-language search, matching another indexed language even when requested-language documents exist, and returning multiple entities that match through different indexed languages in one request.
 - API E2E coverage verifies that lesson attachment filename matches still resolve when the match comes from a non-requested-language document.
+- API E2E coverage verifies that an enrolled course result returns its stored completed-chapter count.
 - Existing frontend behavior is inferred from the global search dialog and query hook; no new frontend E2E coverage was added because the API contract did not change.


### PR DESCRIPTION
## Issue(s)
- #1736 

## Overview

Fixes inconsistent course behavior in global search:

- Returns the enrolled learner’s completed-chapter count for `myCourses` results.
- Routes both regular and enrolled course search results to the learner-facing course page.
- Adds API E2E coverage for displaying stored course progress in search results.
- Updates the global-search business specification with the progress behavior.

## Business Value

Learners see accurate course progress directly in global search and are taken to the correct course experience when selecting a result. This keeps search results consistent with the course list and prevents users from being sent to an administrative course route.
