### PR TITLE
fix: ensure the mention picker stays fully visible in course discussions

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/CourseChatTab.tsx
@@ -139,9 +139,7 @@ export function CourseChatTab({
     >
       <CardContent className="bg-neutral-50 p-0">
         <div className="flex min-h-96 min-w-0 flex-col">
-          <div className="flex flex-1 flex-col gap-3 overflow-y-auto px-3 py-4 md:px-5">
-            {mainFeedContent}
-          </div>
+          <div className="flex flex-1 flex-col gap-3 px-3 py-4 md:px-5">{mainFeedContent}</div>
 
           {messagesResponse?.pagination && messagesResponse.pagination.totalItems > 0 && (
             <Pagination

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWith } from "~/utils/testUtils";
+
+import { MentionTextarea } from "./MentionTextarea";
+
+describe("MentionTextarea", () => {
+  it("renders the mention picker with CSS positioning", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    renderWith().render(
+      <div className="overflow-y-auto">
+        <MentionTextarea
+          value="@men"
+          onChange={onChange}
+          users={[
+            {
+              id: "user-1",
+              firstName: "Mention",
+              lastName: "Target",
+              avatarReference: null,
+              isOnline: false,
+            },
+          ]}
+          placeholder="Write a message"
+          maxLength={5000}
+          testIds={{ mentionList: "mention-list", mentionOption: (id) => `mention-${id}` }}
+        />
+      </div>,
+    );
+
+    const picker = await screen.findByTestId("mention-list");
+
+    expect(picker.parentElement).not.toBe(document.body);
+    expect(picker).toHaveClass("absolute");
+
+    await user.click(screen.getByTestId("mention-user-1"));
+
+    expect(onChange).toHaveBeenCalledWith("@Mention Target ");
+  });
+});

--- a/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseChat/MentionTextarea.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 
+import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
 import { UserAvatar } from "~/components/UserProfile/UserAvatar";
 import { cn } from "~/lib/utils";
@@ -128,11 +129,12 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
               const userName = getUserDisplayName(user);
 
               return (
-                <button
+                <Button
                   key={user.id}
                   type="button"
+                  variant="ghost"
                   className={cn(
-                    "flex w-full items-center gap-3 rounded-lg p-2 text-left hover:bg-neutral-50",
+                    "h-auto w-full justify-start gap-3 p-2 text-left hover:bg-neutral-50",
                     { "bg-neutral-50": index === highlightedIndex },
                   )}
                   data-testid={testIds?.mentionOption?.(user.id)}
@@ -149,7 +151,7 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
                   <span className="body-sm-md min-w-0 flex-1 truncate text-neutral-950">
                     {userName}
                   </span>
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -152,7 +152,7 @@ export default function CourseViewPage() {
       <CourseAccessProvider course={course}>
         <PageWrapper breadcrumbs={breadcrumbs} aboveBreadcrumbs={<LearningModeBanner />}>
           <div className="flex w-full min-w-0 max-w-full flex-col">
-            <div className="flex min-w-0 flex-col gap-y-3 overflow-hidden pb-3 md:gap-y-4 md:pb-4">
+            <div className="flex min-w-0 flex-col gap-y-3 pb-3 md:gap-y-4 md:pb-4">
               <CourseOverview
                 idOrSlug={id}
                 language={language}


### PR DESCRIPTION
## Issue(s)

- #1862

## Overview

Fixes the course discussion mention picker being clipped or overflowing the discussion layout.

- Keeps the picker in the local DOM with CSS-only positioning.
- Removes unnecessary overflow clipping from the course discussion feed and surrounding course layout.
- Uses the shared `Button` component for mention options.
- Adds focused coverage for picker rendering and mention selection.

## Business Value

Learners can reliably mention enrolled course participants without the user picker being cut off, displaced, or difficult to select. This makes course discussions easier to use, especially when a discussion contains only a few messages.

## Screenshots / Video

<img width="563" height="236" alt="image" src="https://github.com/user-attachments/assets/687b7f32-568b-40d0-a407-0617721e9511" />
