### PR TITLE
chore: ensure AI Mentor task description heading styles display correctly

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/LessonPreviewDialog.tsx
@@ -139,7 +139,7 @@ export default function LessonPreviewDialog({
             </DialogHeader>
             <div className="min-h-0 px-6 py-5">
               <div className="max-h-[62vh] overflow-y-auto pr-2 text-left text-sm leading-relaxed text-neutral-800">
-                <Viewer content={lesson.description ?? ""} />
+                <Viewer content={lesson.description ?? ""} style="prose" />
               </div>
             </div>
           </DialogContent>

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -300,7 +300,7 @@ const AiMentorLesson = ({
                   </DialogHeader>
                   <div className="min-h-0 px-6 py-5">
                     <div className={taskDescriptionViewerClassName}>
-                      <Viewer content={lesson.description ?? ""} />
+                      <Viewer content={lesson.description ?? ""} style="prose" />
                     </div>
                   </div>
                 </DialogContent>

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceMentorModeOverlay.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceMentorModeOverlay.tsx
@@ -314,7 +314,7 @@ export function VoiceMentorModeOverlay({
                       </Button>
                     </div>
                     <div className="min-h-0 overflow-y-auto px-6 py-5 text-left text-sm leading-relaxed text-neutral-800">
-                      <Viewer content={taskDescription} />
+                      <Viewer content={taskDescription} style="prose" />
                     </div>
                   </motion.aside>
                 )}


### PR DESCRIPTION
## Issue(s)
- #1741 

## Overview

Apply the prose viewer styling to AI Mentor task descriptions so authored headings and lists retain their visual hierarchy when displayed. The styling is applied to the learner task dialog, voice mentor task panel, and course statistics lesson preview.

## Business Value

Learners and reviewers can scan AI Mentor instructions more easily because structured task descriptions are displayed with the same hierarchy intended by the course creator. This improves clarity for longer scenarios and reduces the risk of important instructions being overlooked.

## Screenshots / Video

<img width="542" height="794" alt="image" src="https://github.com/user-attachments/assets/eeda8ea1-8318-4ee9-ac9b-80d7ae45c603" />
