### PR TITLE
chore: make horizontally scrolling through course lists smoother with improved preloading

### DIFF
--- a/apps/web/app/api/queries/useAvailableCourses.ts
+++ b/apps/web/app/api/queries/useAvailableCourses.ts
@@ -22,7 +22,7 @@ type CourseParams = {
 
 type QueryOptions = {
   enabled?: boolean;
-  notifyOnChangeProps?: Array<"data" | "isLoading" | "hasNextPage">;
+  notifyOnChangeProps?: Array<"data" | "isLoading" | "hasNextPage" | "isFetchingNextPage">;
 };
 
 export const AVAILABLE_COURSES_QUERY_KEY = "available-courses";

--- a/apps/web/app/components/ui/carousel.tsx
+++ b/apps/web/app/components/ui/carousel.tsx
@@ -1,5 +1,5 @@
 import useEmblaCarousel, { type UseEmblaCarouselType } from "embla-carousel-react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "~/components/ui/button";
@@ -140,7 +140,11 @@ type CarouselContentProps = React.HTMLAttributes<HTMLDivElement> & {
 const CarouselContent = React.forwardRef<HTMLDivElement, CarouselContentProps>(
   ({ className, viewportClassName, viewportRef, onWheel, ...props }, ref) => {
     const { carouselRef, orientation, scrollNext, scrollPrev } = useCarousel();
-    const wheelState = React.useRef({ direction: 0, count: 0, timer: null as ReturnType<typeof setTimeout> | null });
+    const wheelState = React.useRef({
+      direction: 0,
+      count: 0,
+      timer: null as ReturnType<typeof setTimeout> | null,
+    });
 
     const setViewportRefs = React.useCallback(
       (node: HTMLDivElement | null) => {
@@ -268,9 +272,25 @@ CarouselPrevious.displayName = "CarouselPrevious";
 
 const CarouselNext = React.forwardRef<
   HTMLButtonElement,
-  React.ComponentProps<typeof Button> & { iconSize?: number; iconClassName?: string }
+  React.ComponentProps<typeof Button> & {
+    iconSize?: number;
+    iconClassName?: string;
+    loading?: boolean;
+  }
 >(
-  ({ className, variant = "outline", size = "icon", iconSize = 16, iconClassName, ...props }, ref) => {
+  (
+    {
+      className,
+      variant = "outline",
+      size = "icon",
+      iconSize = 16,
+      iconClassName,
+      loading = false,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
     const { scrollNext, canScrollNext } = useCarousel();
 
     return (
@@ -279,11 +299,15 @@ const CarouselNext = React.forwardRef<
         variant={variant}
         size={size}
         className={cn(className)}
-        disabled={!canScrollNext}
+        disabled={disabled ?? (loading || !canScrollNext)}
         onClick={scrollNext}
         {...props}
       >
-        <ChevronRight size={iconSize} className={cn("text-black", iconClassName)} />
+        {loading ? (
+          <Loader2 size={iconSize} className={cn("animate-spin text-black", iconClassName)} />
+        ) : (
+          <ChevronRight size={iconSize} className={cn("text-black", iconClassName)} />
+        )}
         <span className="sr-only">Next slide</span>
       </Button>
     );

--- a/apps/web/app/modules/Courses/components/modern/ModernCourseCarousel.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCourseCarousel.tsx
@@ -95,7 +95,6 @@ const ModernCourseCarousel = ({
     };
 
     const fetchNextPageAtEnd = (nextCanScrollNext: boolean) => {
-      if (onWatchedSlideVisible) return;
       if (nextCanScrollNext) return;
       if (!hasNextPage || isFetchingNextPage || !fetchNextPage) return;
 
@@ -129,6 +128,17 @@ const ModernCourseCarousel = ({
     isFetchingNextPage,
     onWatchedSlideVisible,
   ]);
+
+  const handleNextClick = useCallback(() => {
+    if (carouselApi?.canScrollNext()) {
+      carouselApi.scrollNext();
+      return;
+    }
+
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage?.();
+    }
+  }, [carouselApi, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   useEffect(() => {
     const viewportNode = viewportRef.current;
@@ -206,9 +216,12 @@ const ModernCourseCarousel = ({
               className=" left-2 absolute top-1/2 z-[160] border-none flex size-[52px] -translate-y-1/2 items-center justify-center rounded-full bg-black/70 shadow-lg transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:opacity-0 md:group-hover:opacity-100 bg-white hover:border-none duration-200"
             />
           )}
-          {canScrollNext && (
+          {(canScrollNext || hasNextPage) && (
             <CarouselNext
               iconSize={24}
+              disabled={isFetchingNextPage ? true : !canScrollNext && !hasNextPage}
+              loading={isFetchingNextPage}
+              onClick={handleNextClick}
               className="right-2 absolute top-1/2 z-[160] border-none flex size-[52px] -translate-y-1/2 items-center justify-center rounded-full bg-black/70 shadow-lg transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white md:opacity-0 md:group-hover:opacity-100 bg-white hover:border-none duration-200"
             />
           )}
@@ -220,7 +233,7 @@ const ModernCourseCarousel = ({
             className="absolute inset-y-0 left-0 z-[140] w-28 pointer-events-auto"
           />
         )}
-        {canScrollNext && (
+        {(canScrollNext || hasNextPage) && (
           <div
             aria-hidden
             data-testid="course-row-arrow-block-right"
@@ -232,7 +245,7 @@ const ModernCourseCarousel = ({
             <div className="h-full w-full bg-gradient-to-r from-white via-white/80 to-white/0" />
           </div>
         )}
-        {canScrollNext && (
+        {(canScrollNext || hasNextPage) && (
           <div className="pointer-events-none absolute inset-y-0 right-0 w-16 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
             <div className="h-full w-full bg-gradient-to-l from-white via-white/80 to-white/0" />
           </div>

--- a/apps/web/app/modules/Courses/components/modern/ModernCoursesView.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCoursesView.tsx
@@ -51,14 +51,16 @@ const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCo
   const prefetchedAfterPageRef = useRef(0);
   const hasNextPageRef = useRef(false);
   const isCoursePageFetchQueuedRef = useRef(false);
-  const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteAvailableCourses(
-    {
-      category: category.title,
-      language,
-    },
-    COURSE_PAGE_SIZE,
-    { notifyOnChangeProps: ["data", "isLoading", "hasNextPage"] },
-  );
+  const previousVisibleCourseCountRef = useRef<number | null>(null);
+  const { data, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useInfiniteAvailableCourses(
+      {
+        category: category.title,
+        language,
+      },
+      COURSE_PAGE_SIZE,
+      { notifyOnChangeProps: ["data", "isLoading", "hasNextPage", "isFetchingNextPage"] },
+    );
   const fetchNextPageRef = useRef(fetchNextPage);
 
   useEffect(() => {
@@ -71,8 +73,7 @@ const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCo
     [data],
   );
   const loadedCoursePages = data?.pages.length ?? 0;
-  const watchedSlideIndex =
-    loadedCoursePages > 1 ? (loadedCoursePages - 1) * COURSE_PAGE_SIZE : undefined;
+  const watchedSlideIndex = loadedCoursePages > 1 ? courses.length - 1 : undefined;
 
   const prefetchNextPageAfter = useCallback((currentPage: number) => {
     if (prefetchedAfterPageRef.current >= currentPage) return;
@@ -94,6 +95,18 @@ const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCo
 
     prefetchNextPageAfter(1);
   }, [data?.pages.length, prefetchNextPageAfter]);
+
+  useEffect(() => {
+    if (!data?.pages.length) return;
+
+    const previousVisibleCourseCount = previousVisibleCourseCountRef.current;
+    previousVisibleCourseCountRef.current = courses.length;
+
+    if (previousVisibleCourseCount === null) return;
+    if (courses.length > previousVisibleCourseCount) return;
+
+    prefetchNextPageAfter(loadedCoursePages);
+  }, [courses.length, data?.pages.length, loadedCoursePages, prefetchNextPageAfter]);
 
   const handleWatchedSlideVisible = useCallback(
     (slideIndex: number) => {
@@ -117,6 +130,9 @@ const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCo
       title={category.title}
       courses={courses}
       progressByCourseId={progressByCourseId}
+      hasNextPage={hasNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      fetchNextPage={fetchNextPage}
       watchSlideIndex={watchedSlideIndex}
       onWatchedSlideVisible={handleWatchedSlideVisible}
       rowRef={rowRef}


### PR DESCRIPTION
## Issue(s)

- #1710 

## Overview

Improves horizontal scrolling in the modern course list when additional courses are available but have not yet been loaded.

- Keeps the next control visible when more paginated data exists, even when the carousel has no currently loaded overflow.
- Loads the next page when the user reaches the loaded end or activates the next control.
- Shows a loading spinner and prevents duplicate page requests while loading.
- Preserves near-end prefetching and automatically skips pages that contain no visible courses after filtering.
- Corrects watched-slide indexing for filtered course lists.

## Business Value

Learners no longer mistake a temporarily unloaded page for the end of a course row. Course discovery is more reliable across Continue Learning and category rows, reducing friction when browsing larger training catalogs.

## Screenshots / Video


https://github.com/user-attachments/assets/d481c566-d680-457b-a5de-0ef3ecd663b6

