### PR TITLE
chore: improve learner experience with required video progress

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,14 +51,14 @@ on:
 
 jobs:
   playwright:
-    name: Playwright Tests (shard ${{ matrix.shard }}/5)
+    name: Playwright Tests (shard ${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     environment:
       name: e2e
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6]
     env:
       E2E_BROWSER: ${{ github.event_name == 'push' && 'chromium' || (inputs.browser || 'all') }}
       PLAYWRIGHT_SHARD: ${{ matrix.shard }}
@@ -219,13 +219,13 @@ jobs:
         run: |
           case "$E2E_BROWSER" in
             chromium)
-              VITE_TEST=true pnpm playwright test --project chromium --shard="${PLAYWRIGHT_SHARD}/5"
+              VITE_TEST=true pnpm playwright test --project chromium --shard="${PLAYWRIGHT_SHARD}/6"
               ;;
             firefox)
-              VITE_TEST=true pnpm playwright test --project firefox --shard="${PLAYWRIGHT_SHARD}/5"
+              VITE_TEST=true pnpm playwright test --project firefox --shard="${PLAYWRIGHT_SHARD}/6"
               ;;
             all)
-              VITE_TEST=true pnpm playwright test --shard="${PLAYWRIGHT_SHARD}/5"
+              VITE_TEST=true pnpm playwright test --shard="${PLAYWRIGHT_SHARD}/6"
               ;;
             *)
               echo "Unsupported E2E_BROWSER value: $E2E_BROWSER" >&2

--- a/apps/api/src/file/utils/__tests__/streamFileToResponse.spec.ts
+++ b/apps/api/src/file/utils/__tests__/streamFileToResponse.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 import { PassThrough, Writable } from "stream";
 
 import { Logger } from "@nestjs/common";
@@ -7,6 +8,7 @@ import { streamFileToResponse } from "../streamFileToResponse";
 import type { Response } from "express";
 
 class MockResponse extends Writable {
+  req = new EventEmitter();
   headersSent = false;
   headers = new Map<string, string>();
   statusCode = 200;
@@ -60,6 +62,18 @@ describe("streamFileToResponse", () => {
     streamFileToResponse(response as unknown as Response, { stream: fileStream });
 
     response.emit("close");
+
+    expect(fileStream.destroyed).toBe(true);
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("destroys the file stream when the request is aborted", () => {
+    const fileStream = new PassThrough();
+    const response = new MockResponse();
+
+    streamFileToResponse(response as unknown as Response, { stream: fileStream });
+
+    response.req.emit("aborted");
 
     expect(fileStream.destroyed).toBe(true);
     expect(loggerErrorSpy).not.toHaveBeenCalled();

--- a/apps/api/src/file/utils/streamFileToResponse.ts
+++ b/apps/api/src/file/utils/streamFileToResponse.ts
@@ -7,6 +7,7 @@ const logger = new Logger("FileDelivery");
 
 export const streamFileToResponse = (res: Response, file: FileStreamPayload) => {
   let streamTimeout: NodeJS.Timeout | undefined;
+  const req = res.req;
 
   const clearStreamTimeout = () => {
     if (!streamTimeout) return;
@@ -37,6 +38,11 @@ export const streamFileToResponse = (res: Response, file: FileStreamPayload) => 
     if (!res.writableEnded) destroyFileStream();
   };
 
+  const handleRequestAborted = () => {
+    clearStreamTimeout();
+    destroyFileStream();
+  };
+
   const resetStreamTimeout = () => {
     if (!file.streamTimeoutMs) return;
 
@@ -44,7 +50,6 @@ export const streamFileToResponse = (res: Response, file: FileStreamPayload) => 
 
     streamTimeout = setTimeout(() => {
       const message = `File stream timed out after ${file.streamTimeoutMs}ms`;
-      logger.error(message);
       file.stream.destroy(new Error(message));
     }, file.streamTimeoutMs);
   };
@@ -57,6 +62,7 @@ export const streamFileToResponse = (res: Response, file: FileStreamPayload) => 
   res.once("error", handleResponseError);
   res.once("close", handleResponseClose);
   res.once("finish", clearStreamTimeout);
+  req?.once("aborted", handleRequestAborted);
 
   res.setHeader("Accept-Ranges", file.acceptRanges ?? "bytes");
 

--- a/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
+++ b/apps/api/src/lesson/__tests__/lesson.controller.e2e-spec.ts
@@ -208,6 +208,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
         description: expect.stringContaining("Open content"),
         lessonCompleted: false,
         nextLessonId: null,
+        videoCompletionTrackingEnabled: true,
       });
     });
 
@@ -1234,6 +1235,7 @@ describe("LessonController (e2e) - quiz feedback redaction", () => {
         .expect(200);
 
       expect(response.body.data.isQuizFeedbackRedacted).toBe(true);
+      expect(response.body.data.videoCompletionTrackingEnabled).toBe(true);
       expect(response.body.data.quizDetails).toBeDefined();
 
       if (response.body.data.quizDetails.questions) {

--- a/apps/api/src/lesson/services/adminLesson.service.ts
+++ b/apps/api/src/lesson/services/adminLesson.service.ts
@@ -158,6 +158,8 @@ export class AdminLessonService {
       await this.cache.del(getContextKey(data.contextId));
     }
 
+    await this.resourceLibraryService.syncLessonAssetRelations(lesson.id, dbInstance);
+
     await this.adminLessonRepository.updateLessonCountForChapter(lesson.chapterId, dbInstance);
     await this.searchIndexService.refreshLesson(lesson.id, dbInstance);
 

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -41,6 +41,7 @@ import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { PermissionsService } from "src/permissions/permissions.service";
 import { QuestionRepository } from "src/questions/question.repository";
 import { QuestionService } from "src/questions/question.service";
+import { ResourceLibraryService } from "src/resource-library/resource-library.service";
 import {
   chapters,
   courses,
@@ -52,7 +53,10 @@ import {
 import { StudentLessonProgressService } from "src/studentLessonProgress/studentLessonProgress.service";
 import { isQuizAccessAllowed } from "src/utils/isQuizAccessAllowed";
 
-import { createLessonResourceIdRegex } from "../lesson-resource-references";
+import {
+  createLessonResourceIdRegex,
+  extractLessonResourceIds,
+} from "../lesson-resource-references";
 import { LESSON_TYPES } from "../lesson.type";
 import { LessonRepository } from "../repositories/lesson.repository";
 
@@ -87,6 +91,7 @@ export class LessonService {
     private readonly permissionsService: PermissionsService,
     private readonly liveTrainingService: LiveTrainingService,
     private readonly lessonVideoProgressService: LessonVideoProgressService,
+    private readonly resourceLibraryService: ResourceLibraryService,
   ) {}
 
   async getLessonById(
@@ -670,13 +675,31 @@ export class LessonService {
     actualLanguage: SupportedLanguages,
     userId?: UUIDType | null,
   ): Promise<LessonShow> {
-    const lessonResources = await this.fileService.getResourcesForEntity(
+    let lessonResources = await this.fileService.getResourcesForEntity(
       id,
       ENTITY_TYPES.LESSON,
       RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
       actualLanguage,
       { quality: IMAGE_QUALITY.MD },
     );
+
+    const attachedResourceReferences = new Set(
+      lessonResources.flatMap((resource) => [resource.id, resource.resourceEntityId]),
+    );
+    const hasMissingResourceRelation = extractLessonResourceIds(lesson.description ?? "").some(
+      (resourceId) => !attachedResourceReferences.has(resourceId),
+    );
+
+    if (hasMissingResourceRelation) {
+      await this.resourceLibraryService.syncLessonAssetRelations(id);
+      lessonResources = await this.fileService.getResourcesForEntity(
+        id,
+        ENTITY_TYPES.LESSON,
+        RESOURCE_RELATIONSHIP_TYPES.ATTACHMENT,
+        actualLanguage,
+        { quality: IMAGE_QUALITY.MD },
+      );
+    }
 
     const videoResourceEntityIds = lessonResources
       .filter((resource) => resource.contentType?.startsWith("video/") && resource.resourceEntityId)

--- a/apps/api/src/resource-library/resource-library.repository.ts
+++ b/apps/api/src/resource-library/resource-library.repository.ts
@@ -356,8 +356,8 @@ export class ResourceLibraryRepository {
       .onConflictDoNothing();
   }
 
-  async getLessonContent(lessonId: UUIDType) {
-    const [lesson] = await this.db
+  async getLessonContent(lessonId: UUIDType, dbInstance: DatabasePg = this.db) {
+    const [lesson] = await dbInstance
       .select({ description: lessons.description })
       .from(lessons)
       .where(eq(lessons.id, lessonId))

--- a/apps/api/src/resource-library/resource-library.service.ts
+++ b/apps/api/src/resource-library/resource-library.service.ts
@@ -299,13 +299,14 @@ export class ResourceLibraryService {
     return { updatedIds, skippedIds, requiresConfirmation: false, affectedUsedAssetCount };
   }
 
-  async syncLessonAssetRelations(lessonId: UUIDType) {
-    const description = await this.resourceLibraryRepository.getLessonContent(lessonId);
+  async syncLessonAssetRelations(lessonId: UUIDType, dbInstance?: DatabasePg) {
+    const description = await this.resourceLibraryRepository.getLessonContent(lessonId, dbInstance);
 
     await this.syncEntityAssetRelations({
       entityId: lessonId,
       entityType: ENTITY_TYPES.LESSON,
       contents: getLocalizedRichTextEntries(description).map(([, content]) => content),
+      dbInstance,
     });
   }
 
@@ -419,21 +420,28 @@ export class ResourceLibraryService {
     entityId: UUIDType;
     entityType: RichTextAssetEntityType;
     contents: string[];
+    dbInstance?: DatabasePg;
   }) {
     const resourceIds = [
       ...new Set(params.contents.flatMap((content) => extractResourceIdsFromRichText(content))),
     ] as UUIDType[];
 
-    await this.db.transaction(async (trx) =>
+    const replaceRelations = (dbInstance: DatabasePg) =>
       this.resourceLibraryRepository.replaceEntityAttachmentRelations(
         {
           entityId: params.entityId,
           entityType: params.entityType,
           resourceIds,
         },
-        trx,
-      ),
-    );
+        dbInstance,
+      );
+
+    if (params.dbInstance) {
+      await replaceRelations(params.dbInstance);
+      return;
+    }
+
+    await this.db.transaction(replaceRelations);
   }
 
   private async removeAssetReferencesFromContent(resourceId: UUIDType, dbInstance: DatabasePg) {

--- a/apps/web/app/api/queries/calendar/useMicrosoftCalendarConnection.ts
+++ b/apps/web/app/api/queries/calendar/useMicrosoftCalendarConnection.ts
@@ -15,6 +15,6 @@ export const microsoftCalendarConnectionQueryOptions = queryOptions({
     query.state.data?.status === MICROSOFT_CALENDAR_CONNECTION_STATUSES.SYNCING ? 3_000 : false,
 });
 
-export function useMicrosoftCalendarConnection() {
-  return useQuery(microsoftCalendarConnectionQueryOptions);
+export function useMicrosoftCalendarConnection(enabled = true) {
+  return useQuery({ ...microsoftCalendarConnectionQueryOptions, enabled });
 }

--- a/apps/web/app/components/RichText/Viever.tsx
+++ b/apps/web/app/components/RichText/Viever.tsx
@@ -27,6 +27,7 @@ type ViewerProps = {
     lessonId?: string;
     language?: SupportedLanguages;
     onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
+    onVideoActivated?: (resourceEntityId: string) => void;
   };
 };
 

--- a/apps/web/app/components/RichText/extensions/video.tsx
+++ b/apps/web/app/components/RichText/extensions/video.tsx
@@ -35,6 +35,7 @@ type VideoViewerOptions = {
     lessonId?: string;
     language?: SupportedLanguages;
     onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
+    onVideoActivated?: (resourceEntityId: string) => void;
   };
 };
 
@@ -258,6 +259,7 @@ const VideoViewerView = ({ node, extension }: NodeViewProps) => {
           initialDurationSeconds: attrs.videoDurationSeconds,
           initialBucketSizeSeconds: attrs.videoBucketSizeSeconds,
           onSnapshotChange: videoCoverageTracking?.onSnapshotChange,
+          onVideoActivated: videoCoverageTracking?.onVideoActivated,
         }}
       />
     </NodeViewWrapper>

--- a/apps/web/app/components/VideoPlayer/Video.tsx
+++ b/apps/web/app/components/VideoPlayer/Video.tsx
@@ -1,5 +1,5 @@
 import { VIDEO_EMBED_PROVIDERS } from "@repo/shared";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useThumbnail } from "~/api/queries/useThumbnail";
 import { Icon } from "~/components/Icon";
@@ -25,9 +25,37 @@ type Props = {
   coverageTracking?: VideoCoverageTrackingOptions;
 };
 
+const VIDEO_PAUSE_EVENT = "mentingo:lesson-videos-pause";
+const VIDEO_RESUME_EVENT = "mentingo:lesson-video-resume";
+
+type ResumeVideoEvent = CustomEvent<{ resourceEntityId: string; requestId: number }>;
+
+let playbackRequestId = 0;
+
+export const pauseAllLessonVideos = () => {
+  if (typeof window === "undefined") return;
+
+  playbackRequestId += 1;
+  window.dispatchEvent(new CustomEvent(VIDEO_PAUSE_EVENT, { detail: playbackRequestId }));
+};
+
+export const resumeLessonVideo = (resourceEntityId: string) => {
+  if (typeof window === "undefined") return;
+
+  playbackRequestId += 1;
+  window.dispatchEvent(
+    new CustomEvent<ResumeVideoEvent["detail"]>(VIDEO_RESUME_EVENT, {
+      detail: { resourceEntityId, requestId: playbackRequestId },
+    }),
+  );
+};
+
 export function Video({ src, url, provider, index = null, onEnded, coverageTracking }: Props) {
   const [isActive, setIsActive] = useState(false);
+  const [pauseRequestId, setPauseRequestId] = useState<number>();
+  const [resumeRequestId, setResumeRequestId] = useState<number>();
   const [aspectRatio, setAspectRatio] = useState(DEFAULT_VIDEO_ASPECT_RATIO);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   const { data: thumbnailUrl } = useThumbnail(src, provider);
 
@@ -38,7 +66,35 @@ export function Video({ src, url, provider, index = null, onEnded, coverageTrack
     if (!resolvedUrl) return;
 
     setIsActive(true);
-  }, [resolvedUrl]);
+
+    containerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+
+    if (coverageTracking?.resourceEntityId) {
+      coverageTracking.onVideoActivated?.(coverageTracking.resourceEntityId);
+    }
+  }, [coverageTracking, resolvedUrl]);
+
+  useEffect(() => {
+    const handlePause = (event: Event) => {
+      setPauseRequestId((event as CustomEvent<number>).detail);
+    };
+
+    const handleResume = (event: Event) => {
+      const detail = (event as ResumeVideoEvent).detail;
+      if (detail.resourceEntityId !== coverageTracking?.resourceEntityId) return;
+
+      setResumeRequestId(detail.requestId);
+      handleActivate();
+    };
+
+    window.addEventListener(VIDEO_PAUSE_EVENT, handlePause);
+    window.addEventListener(VIDEO_RESUME_EVENT, handleResume);
+
+    return () => {
+      window.removeEventListener(VIDEO_PAUSE_EVENT, handlePause);
+      window.removeEventListener(VIDEO_RESUME_EVENT, handleResume);
+    };
+  }, [coverageTracking?.resourceEntityId, handleActivate]);
 
   const handleThumbnailLoad = useCallback((event: SyntheticEvent<HTMLImageElement>) => {
     const { naturalWidth, naturalHeight } = event.currentTarget;
@@ -80,7 +136,7 @@ export function Video({ src, url, provider, index = null, onEnded, coverageTrack
   );
 
   return (
-    <div className="w-full">
+    <div ref={containerRef} className="w-full">
       <div className="relative w-full overflow-hidden rounded-none bg-black" style={wrapperStyle}>
         {isActive && resolvedUrl ? (
           <div className="relative size-full rounded-none bg-black">
@@ -92,6 +148,8 @@ export function Video({ src, url, provider, index = null, onEnded, coverageTrack
               onAspectRatioChange={setAspectRatio}
               onEnded={handleEnded}
               coverageTracking={coverageTracking}
+              pauseRequestId={pauseRequestId}
+              resumeRequestId={resumeRequestId}
               className="size-full"
             />
           </div>

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -284,12 +284,28 @@ export const VideoPlayer = ({
   }, []);
 
   useEffect(() => {
-    if (!player || pauseRequestId === undefined) return;
+    if (
+      !player ||
+      pauseRequestId === undefined ||
+      player.isDisposed() ||
+      !player.el()?.isConnected
+    ) {
+      return;
+    }
+
     player.pause();
   }, [pauseRequestId, player]);
 
   useEffect(() => {
-    if (!player || resumeRequestId === undefined) return;
+    if (
+      !player ||
+      resumeRequestId === undefined ||
+      player.isDisposed() ||
+      !player.el()?.isConnected
+    ) {
+      return;
+    }
+
     void player.play()?.catch(() => undefined);
   }, [resumeRequestId, player]);
 

--- a/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
+++ b/apps/web/app/components/VideoPlayer/VideoPlayer.tsx
@@ -45,6 +45,8 @@ interface VideoPlayerProps {
   className?: string;
   provider: VideoProvider;
   coverageTracking?: VideoCoverageTrackingOptions;
+  pauseRequestId?: number;
+  resumeRequestId?: number;
 }
 
 type VideoJSType = ReturnType<typeof videojs>;
@@ -178,6 +180,8 @@ export const VideoPlayer = ({
   fill = true,
   className,
   coverageTracking,
+  pauseRequestId,
+  resumeRequestId,
 }: VideoPlayerProps) => {
   const [controlsVisible, setControlsVisible] = useState(true);
   const [player, setPlayer] = useState<VideoJSType | null>(null);
@@ -278,6 +282,16 @@ export const VideoPlayer = ({
 
     player.pause();
   }, []);
+
+  useEffect(() => {
+    if (!player || pauseRequestId === undefined) return;
+    player.pause();
+  }, [pauseRequestId, player]);
+
+  useEffect(() => {
+    if (!player || resumeRequestId === undefined) return;
+    void player.play()?.catch(() => undefined);
+  }, [resumeRequestId, player]);
 
   const seekBy = useCallback((player: VideoJSType, secondsDelta: number) => {
     const currentTime = getFiniteNumber(player.currentTime()) ?? 0;

--- a/apps/web/app/components/VideoPlayer/__tests__/VideoPlayer.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/VideoPlayer.test.tsx
@@ -9,7 +9,7 @@ import { VideoPlayer } from "../VideoPlayer";
 type PlayerListener = () => void;
 
 class FakeVideoJsPlayer {
-  readonly element = document.createElement("div");
+  element: HTMLElement = document.createElement("div");
 
   private listeners = new Map<string, Set<PlayerListener>>();
   private videoTime = 20;
@@ -134,7 +134,10 @@ vi.mock("../hlsQualityControlComponent", () => ({
   addHlsQualityControlComponent: () => addHlsQualityControlComponent(),
 }));
 vi.mock("video.js", () => ({
-  default: vi.fn(() => player),
+  default: vi.fn((element: HTMLElement) => {
+    player.element = element;
+    return player;
+  }),
 }));
 
 const renderPlayer = async () => {
@@ -247,6 +250,26 @@ describe("VideoPlayer keyboard shortcuts", () => {
     playerContainer.appendChild(button);
 
     fireEvent.keyDown(screen.getByRole("button", { name: "Control" }), { key: " " });
+
+    expect(player.play).not.toHaveBeenCalled();
+    expect(player.pause).not.toHaveBeenCalled();
+  });
+
+  it("does not send playback commands to a detached player", async () => {
+    const view = renderWith({ withQuery: true }).render(
+      <VideoPlayer provider={VIDEO_EMBED_PROVIDERS.SELF} url="https://example.com/video.mp4" />,
+    );
+    await waitFor(() => expect(player.element).toBeInTheDocument());
+
+    player.element.remove();
+    view.rerender(
+      <VideoPlayer
+        provider={VIDEO_EMBED_PROVIDERS.SELF}
+        url="https://example.com/video.mp4"
+        pauseRequestId={1}
+        resumeRequestId={1}
+      />,
+    );
 
     expect(player.play).not.toHaveBeenCalled();
     expect(player.pause).not.toHaveBeenCalled();

--- a/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
@@ -17,11 +17,14 @@ type VideoJSType = ReturnType<typeof videojs>;
 type PlayerEvent = "timeupdate" | "play" | "pause" | "seeking" | "seeked" | "ended";
 
 class FakeVideoPlayer {
+  private readonly element = document.createElement("div");
   private listeners = new Map<PlayerEvent, Set<() => void>>();
   private videoTime = 0;
   private pausedValue = true;
 
-  constructor(private readonly durationValue = 100) {}
+  constructor(private readonly durationValue = 100) {
+    document.body.appendChild(this.element);
+  }
 
   on(eventName: PlayerEvent, listener: () => void) {
     const listeners = this.listeners.get(eventName) ?? new Set();
@@ -62,6 +65,23 @@ class FakeVideoPlayer {
   playbackRate() {
     return 1;
   }
+
+  el() {
+    return this.element;
+  }
+
+  isDisposed() {
+    return false;
+  }
+
+  disconnect() {
+    this.element.remove();
+  }
+
+  pause() {
+    this.pausedValue = true;
+    this.emit("pause");
+  }
 }
 
 const createProgressResponse = (watchedRanges: VideoCoverageRange[], durationSeconds = 100) => ({
@@ -97,6 +117,7 @@ describe("useVideoCoverageTracker", () => {
   });
 
   afterEach(() => {
+    document.body.replaceChildren();
     vi.restoreAllMocks();
   });
 
@@ -170,6 +191,145 @@ describe("useVideoCoverageTracker", () => {
         activeWatchSecondsDelta: 4.6,
       }),
     );
+  });
+
+  it("does not collect coverage when the player is paused without emitting a pause event", async () => {
+    const player = new FakeVideoPlayer();
+
+    const { result } = renderHook(() =>
+      useVideoCoverageTracker(player as unknown as VideoJSType, {
+        enabled: true,
+        lessonId: "lesson-id",
+        resourceEntityId: "resource-entity-id",
+        initialBucketSizeSeconds: 1,
+      }),
+    );
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(0);
+      player.emit("play");
+      now = 5_000;
+      player.setCurrentTime(4.6);
+      player.emit("timeupdate");
+
+      player.setPaused(true);
+      now = 8_000;
+      player.setCurrentTime(7.6);
+      player.emit("timeupdate");
+    });
+
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        watchedRanges: [[0, 5]],
+        activeWatchSecondsDelta: 4.6,
+      }),
+    );
+  });
+
+  it("stops a detached player before it can collect background coverage", async () => {
+    const player = new FakeVideoPlayer();
+
+    const { result } = renderHook(() =>
+      useVideoCoverageTracker(player as unknown as VideoJSType, {
+        enabled: true,
+        lessonId: "lesson-id",
+        resourceEntityId: "resource-entity-id",
+        initialBucketSizeSeconds: 1,
+      }),
+    );
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(0);
+      player.emit("play");
+      now = 5_000;
+      player.setCurrentTime(4.6);
+      player.emit("timeupdate");
+
+      player.disconnect();
+      now = 8_000;
+      player.setCurrentTime(7.6);
+      player.emit("timeupdate");
+    });
+
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        watchedRanges: [[0, 5]],
+        activeWatchSecondsDelta: 4.6,
+      }),
+    );
+  });
+
+  it("flushes progress collected after resuming when the previous pause save is in flight", async () => {
+    const player = new FakeVideoPlayer();
+    let resolveFirstSave: ((value: ReturnType<typeof createProgressResponse>) => void) | undefined;
+
+    mutateAsync
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSave = resolve;
+          }),
+      )
+      .mockImplementationOnce((body: { watchedRanges: VideoCoverageRange[] }) =>
+        Promise.resolve(createProgressResponse(body.watchedRanges)),
+      );
+
+    const { result } = renderHook(() =>
+      useVideoCoverageTracker(player as unknown as VideoJSType, {
+        enabled: true,
+        lessonId: "lesson-id",
+        resourceEntityId: "resource-entity-id",
+        initialBucketSizeSeconds: 1,
+      }),
+    );
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(0);
+      player.emit("play");
+      now = 5_000;
+      player.setCurrentTime(4.6);
+      player.emit("timeupdate");
+      player.setPaused(true);
+      player.emit("pause");
+    });
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(5);
+      player.emit("play");
+      now = 7_000;
+      player.setCurrentTime(7);
+      player.emit("timeupdate");
+      player.setPaused(true);
+      player.emit("pause");
+    });
+
+    await act(async () => {
+      resolveFirstSave?.(createProgressResponse([[0, 5]]));
+    });
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(2));
+    expect(mutateAsync).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        watchedRanges: [[5, 7]],
+        activeWatchSecondsDelta: 2,
+      }),
+    );
+    expect(result.current.snapshot.watchedRanges).toEqual([[0, 7]]);
   });
 
   it("does not count skipped time when the player seeks", async () => {

--- a/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
+++ b/apps/web/app/components/VideoPlayer/__tests__/useVideoCoverageTracker.test.tsx
@@ -136,6 +136,42 @@ describe("useVideoCoverageTracker", () => {
     });
   });
 
+  it("stops collecting coverage immediately when a pause event fires", async () => {
+    const player = new FakeVideoPlayer();
+
+    renderHook(() =>
+      useVideoCoverageTracker(player as unknown as VideoJSType, {
+        enabled: true,
+        lessonId: "lesson-id",
+        resourceEntityId: "resource-entity-id",
+        initialBucketSizeSeconds: 1,
+      }),
+    );
+
+    act(() => {
+      player.setPaused(false);
+      player.setCurrentTime(0);
+      player.emit("play");
+      now = 5_000;
+      player.setCurrentTime(4.6);
+      player.emit("timeupdate");
+
+      // Some video providers update their paused state after emitting pause.
+      player.emit("pause");
+      now = 8_000;
+      player.setCurrentTime(7.6);
+      player.emit("timeupdate");
+    });
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        watchedRanges: [[0, 5]],
+        activeWatchSecondsDelta: 4.6,
+      }),
+    );
+  });
+
   it("does not count skipped time when the player seeks", async () => {
     const player = new FakeVideoPlayer();
 

--- a/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
+++ b/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
@@ -102,6 +102,7 @@ export const useVideoCoverageTracker = (
   const snapshotDurationSecondsRef = useRef(snapshot.durationSeconds);
   const isSeekingRef = useRef(false);
   const isFlushingRef = useRef(false);
+  const flushRequestedRef = useRef(false);
   const pendingLessonCompletionSyncRef = useRef(false);
   const completionSyncRequestedRef = useRef(false);
   const {
@@ -220,6 +221,10 @@ export const useVideoCoverageTracker = (
         completionSyncRequestedRef.current = true;
       }
 
+      if (isFlushingRef.current) {
+        flushRequestedRef.current = true;
+      }
+
       if (
         !currentOptions.enabled ||
         !currentOptions.lessonId ||
@@ -252,12 +257,26 @@ export const useVideoCoverageTracker = (
           language: currentOptions.language,
         });
 
-        setSnapshot({
-          coveragePercent: progress.coveragePercent,
-          watchedRanges: progress.watchedRanges,
-          isWatched: progress.isWatched,
-          durationSeconds: progress.durationSeconds,
-          bucketSizeSeconds: progress.bucketSizeSeconds,
+        setSnapshot((current) => {
+          const watchedRanges = mergeVideoCoverageRanges([
+            ...progress.watchedRanges,
+            ...current.watchedRanges,
+          ]);
+          const coveragePercent = progress.durationSeconds
+            ? Math.min(1, countVideoCoverageRangeUnits(watchedRanges) / progress.durationSeconds)
+            : current.coveragePercent;
+
+          return {
+            coveragePercent: Math.max(
+              progress.coveragePercent,
+              current.coveragePercent,
+              coveragePercent,
+            ),
+            watchedRanges,
+            isWatched: progress.isWatched || current.isWatched,
+            durationSeconds: progress.durationSeconds,
+            bucketSizeSeconds: progress.bucketSizeSeconds,
+          };
         });
 
         if (progress.lessonCompleted) {
@@ -280,6 +299,15 @@ export const useVideoCoverageTracker = (
         activeWatchSecondsDeltaRef.current += activeWatchSecondsDelta;
       } finally {
         isFlushingRef.current = false;
+
+        if (flushRequestedRef.current) {
+          flushRequestedRef.current = false;
+          const syncCompletionQueries = completionSyncRequestedRef.current;
+
+          queueMicrotask(() => {
+            void flush({ syncCompletionQueries });
+          });
+        }
       }
     },
     [player, syncPendingLessonCompletion, upsertVideoProgress],
@@ -289,8 +317,21 @@ export const useVideoCoverageTracker = (
     if (!enabled || !player) return;
 
     const handleTimeUpdate = () => {
+      if (player.isDisposed() || !player.el()?.isConnected) {
+        isPlayingRef.current = false;
+        previousSampleRef.current = null;
+
+        return;
+      }
+
       const currentVideoTime = player.currentTime();
       const now = performance.now();
+
+      if (player.paused()) {
+        isPlayingRef.current = false;
+        previousSampleRef.current = null;
+        return;
+      }
 
       if (typeof currentVideoTime !== "number" || !Number.isFinite(currentVideoTime)) {
         previousSampleRef.current = null;
@@ -342,8 +383,14 @@ export const useVideoCoverageTracker = (
     player.on("seeked", handleSeeked);
     player.on("ended", handleEnded);
     document.addEventListener("visibilitychange", handleVisibilityChange);
-    isPlayingRef.current = !player.paused();
-    resetPreviousSample();
+    const isPlayerConnected = !player.isDisposed() && Boolean(player.el()?.isConnected);
+    isPlayingRef.current = isPlayerConnected && !player.paused();
+
+    if (isPlayerConnected) {
+      resetPreviousSample();
+    } else {
+      previousSampleRef.current = null;
+    }
 
     const flushInterval = window.setInterval(
       () => void flush(),

--- a/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
+++ b/apps/web/app/components/VideoPlayer/useVideoCoverageTracker.ts
@@ -98,6 +98,7 @@ export const useVideoCoverageTracker = (
   const pendingRangesRef = useRef<VideoCoverageRange[]>([]);
   const activeWatchSecondsDeltaRef = useRef(0);
   const previousSampleRef = useRef<{ videoTime: number; wallClock: number } | null>(null);
+  const isPlayingRef = useRef(false);
   const snapshotDurationSecondsRef = useRef(snapshot.durationSeconds);
   const isSeekingRef = useRef(false);
   const isFlushingRef = useRef(false);
@@ -299,7 +300,7 @@ export const useVideoCoverageTracker = (
       const previousSample = previousSampleRef.current;
       previousSampleRef.current = { videoTime: currentVideoTime, wallClock: now };
 
-      if (!previousSample || isSeekingRef.current || player.paused()) return;
+      if (!previousSample || isSeekingRef.current || !isPlayingRef.current) return;
 
       const mediaDelta = currentVideoTime - previousSample.videoTime;
       const wallDelta = (now - previousSample.wallClock) / 1000;
@@ -312,8 +313,15 @@ export const useVideoCoverageTracker = (
       }
     };
 
-    const handlePlay = () => resetPreviousSample();
-    const handlePause = () => void flush({ syncCompletionQueries: true });
+    const handlePlay = () => {
+      isPlayingRef.current = true;
+      resetPreviousSample();
+    };
+    const handlePause = () => {
+      isPlayingRef.current = false;
+      previousSampleRef.current = null;
+      void flush({ syncCompletionQueries: true });
+    };
     const handleSeeking = () => {
       isSeekingRef.current = true;
       previousSampleRef.current = null;
@@ -334,6 +342,7 @@ export const useVideoCoverageTracker = (
     player.on("seeked", handleSeeked);
     player.on("ended", handleEnded);
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    isPlayingRef.current = !player.paused();
     resetPreviousSample();
 
     const flushInterval = window.setInterval(
@@ -350,6 +359,7 @@ export const useVideoCoverageTracker = (
       player.off("seeked", handleSeeked);
       player.off("ended", handleEnded);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      isPlayingRef.current = false;
       void flush({ syncCompletionQueries: true });
     };
   }, [enabled, flush, markRangeAsWatched, options.flushIntervalMs, player, resetPreviousSample]);

--- a/apps/web/app/components/VideoPlayer/videoCoverage.types.ts
+++ b/apps/web/app/components/VideoPlayer/videoCoverage.types.ts
@@ -28,4 +28,5 @@ export type VideoCoverageTrackingOptions = {
   initialBucketSizeSeconds?: number | null;
   flushIntervalMs?: number;
   onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
+  onVideoActivated?: (resourceEntityId: string) => void;
 };

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -3752,6 +3752,8 @@
       "completedSummary": "Dokončeno {{completed}} z {{total}}",
       "overviewAriaLabel": "Průběh videí v lekci",
       "segmentAriaLabel": "Průběh videa {{index}}: zhlédnuto {{progress}} %",
+      "requirementSingle": "Pro dokončení této lekce zhlédněte celé video.",
+      "requirementMultiple": "Pro dokončení této lekce zhlédněte všechna videa.",
       "errors": {
         "resourceNotFound": "Postup videa pro tuto lekci se nepodařilo uložit.",
         "unsupportedLessonType": "Postup videa je dostupný pouze pro obsahové lekce.",
@@ -3760,6 +3762,14 @@
         "trackingDisabled": "Sledování dokončení videa je pro tento kurz vypnuto.",
         "accessDenied": "Nemáte přístup k aktualizaci postupu videa pro tuto lekci."
       }
+    },
+    "requiredVideoLeave": {
+      "title": "Dokončit sledování před odchodem?",
+      "descriptionSingle": "Před dokončením této lekce je nutné zhlédnout celé video.",
+      "descriptionMultiple": "Před dokončením této lekce je nutné zhlédnout všechna videa.",
+      "exitAnyway": "Přesto odejít",
+      "continueWatching": "Pokračovat ve sledování",
+      "remember": "Skrýt pro tento kurz"
     },
     "playNext": {
       "title": "Další",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -3746,6 +3746,8 @@
       "completedSummary": "{{completed}} von {{total}} abgeschlossen",
       "overviewAriaLabel": "Video-Fortschritt der Lektion",
       "segmentAriaLabel": "Fortschritt von Video {{index}}: {{progress}} % angesehen",
+      "requirementSingle": "Sehen Sie das gesamte Video an, um diese Lektion abzuschließen.",
+      "requirementMultiple": "Sehen Sie alle Videos an, um diese Lektion abzuschließen.",
       "errors": {
         "resourceNotFound": "Der Videofortschritt konnte für diese Lektion nicht gespeichert werden.",
         "unsupportedLessonType": "Videofortschritt ist nur für Inhaltslektionen verfügbar.",
@@ -3754,6 +3756,14 @@
         "trackingDisabled": "Video-Abschlussverfolgung ist für diesen Kurs deaktiviert.",
         "accessDenied": "Sie haben keinen Zugriff, um den Videofortschritt für diese Lektion zu aktualisieren."
       }
+    },
+    "requiredVideoLeave": {
+      "title": "Vor dem Verlassen weitersehen?",
+      "descriptionSingle": "Das gesamte Video muss angesehen werden, bevor diese Lektion abgeschlossen werden kann.",
+      "descriptionMultiple": "Alle Videos müssen angesehen werden, bevor diese Lektion abgeschlossen werden kann.",
+      "exitAnyway": "Trotzdem verlassen",
+      "continueWatching": "Weitersehen",
+      "remember": "Für diesen Kurs nicht mehr anzeigen"
     },
     "playNext": {
       "title": "Als nächstes",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -3751,6 +3751,8 @@
       "completedSummary": "{{completed}} of {{total}} completed",
       "overviewAriaLabel": "Lesson video progress",
       "segmentAriaLabel": "Video {{index}} progress: {{progress}}% watched",
+      "requirementSingle": "Watch the entire video to complete this lesson.",
+      "requirementMultiple": "Watch all videos to complete this lesson.",
       "errors": {
         "resourceNotFound": "Video progress could not be saved for this lesson.",
         "unsupportedLessonType": "Video progress is only available for content lessons.",
@@ -3759,6 +3761,14 @@
         "trackingDisabled": "Video completion tracking is disabled for this course.",
         "accessDenied": "You do not have access to update video progress for this lesson."
       }
+    },
+    "requiredVideoLeave": {
+      "title": "Finish watching before leaving?",
+      "descriptionSingle": "This lesson requires the entire video to be watched before it can be completed.",
+      "descriptionMultiple": "This lesson requires all videos to be watched before it can be completed.",
+      "exitAnyway": "Exit anyway",
+      "continueWatching": "Continue watching",
+      "remember": "Dismiss for this course"
     },
     "playNext": {
       "title": "Up next",

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -3691,6 +3691,8 @@
       "completedSummary": "{{completed}} de {{total}} completados",
       "overviewAriaLabel": "Progreso de los videos de la lección",
       "segmentAriaLabel": "Progreso del video {{index}}: {{progress}}% visto",
+      "requirementSingle": "Mira el vídeo completo para completar esta lección.",
+      "requirementMultiple": "Mira todos los vídeos para completar esta lección.",
       "errors": {
         "resourceNotFound": "No se pudo guardar el progreso del video para esta lección.",
         "unsupportedLessonType": "El progreso del video solo está disponible para lecciones de contenido.",
@@ -3699,6 +3701,14 @@
         "trackingDisabled": "El seguimiento de finalización de video está deshabilitado para este curso.",
         "accessDenied": "No tienes acceso para actualizar el progreso del video para esta lección."
       }
+    },
+    "requiredVideoLeave": {
+      "title": "¿Continuar viendo antes de salir?",
+      "descriptionSingle": "Debes ver el vídeo completo antes de poder completar esta lección.",
+      "descriptionMultiple": "Debes ver todos los vídeos antes de poder completar esta lección.",
+      "exitAnyway": "Salir de todos modos",
+      "continueWatching": "Continuar viendo",
+      "remember": "No mostrar más en este curso"
     },
     "playNext": {
       "title": "A continuación",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -3747,6 +3747,8 @@
       "completedSummary": "Užbaigta {{completed}} iš {{total}}",
       "overviewAriaLabel": "Pamokos vaizdo įrašų eiga",
       "segmentAriaLabel": "{{index}} vaizdo įrašo eiga: peržiūrėta {{progress}}%",
+      "requirementSingle": "Peržiūrėkite visą vaizdo įrašą, kad užbaigtumėte šią pamoką.",
+      "requirementMultiple": "Peržiūrėkite visus vaizdo įrašus, kad užbaigtumėte šią pamoką.",
       "errors": {
         "resourceNotFound": "Nepavyko išsaugoti šios pamokos vaizdo įrašo pažangos.",
         "unsupportedLessonType": "Vaizdo įrašo pažanga pasiekiama tik turinio pamokoms.",
@@ -3755,6 +3757,14 @@
         "trackingDisabled": "Vaizdo įrašo užbaigimo sekimas šiame kurse išjungtas.",
         "accessDenied": "Neturite prieigos atnaujinti šios pamokos vaizdo įrašo pažangos."
       }
+    },
+    "requiredVideoLeave": {
+      "title": "Peržiūrėti prieš išeinant?",
+      "descriptionSingle": "Norint užbaigti šią pamoką, reikia peržiūrėti visą vaizdo įrašą.",
+      "descriptionMultiple": "Norint užbaigti šią pamoką, reikia peržiūrėti visus vaizdo įrašus.",
+      "exitAnyway": "Išeiti vis tiek",
+      "continueWatching": "Tęsti peržiūrą",
+      "remember": "Nerodyti šiame kurse"
     },
     "playNext": {
       "title": "Toliau",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -3985,6 +3985,8 @@
       "completedSummary": "Ukończono {{completed}} z {{total}}",
       "overviewAriaLabel": "Postęp wideo w lekcji",
       "segmentAriaLabel": "Postęp wideo {{index}}: obejrzano {{progress}}%",
+      "requirementSingle": "Obejrzyj całe wideo, aby ukończyć tę lekcję.",
+      "requirementMultiple": "Obejrzyj wszystkie wideo, aby ukończyć tę lekcję.",
       "errors": {
         "resourceNotFound": "Nie udało się zapisać postępu wideo dla tej lekcji.",
         "unsupportedLessonType": "Postęp wideo jest dostępny tylko dla lekcji z treścią.",
@@ -3993,6 +3995,14 @@
         "trackingDisabled": "Śledzenie ukończenia wideo jest wyłączone dla tego kursu.",
         "accessDenied": "Nie masz dostępu do aktualizacji postępu wideo dla tej lekcji."
       }
+    },
+    "requiredVideoLeave": {
+      "title": "Obejrzeć wideo przed wyjściem?",
+      "descriptionSingle": "Aby ukończyć tę lekcję, musisz obejrzeć całe wideo.",
+      "descriptionMultiple": "Aby ukończyć tę lekcję, musisz obejrzeć wszystkie wideo.",
+      "exitAnyway": "Wyjdź mimo to",
+      "continueWatching": "Kontynuuj oglądanie",
+      "remember": "Ukryj dla tego kursu"
     },
     "playNext": {
       "title": "Następnie",

--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -3,7 +3,7 @@ import { first, get, last, orderBy } from "lodash-es";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useCourse, useCurrentUser, useLesson } from "~/api/queries";
+import { lessonQueryOptions, useCourse, useCurrentUser, useLesson } from "~/api/queries";
 import { courseQueryOptions, getCourseQueryKey } from "~/api/queries/useCourse";
 import { queryClient } from "~/api/queryClient";
 import ErrorPage from "~/components/ErrorPage/ErrorPage";
@@ -48,6 +48,9 @@ export default function LessonPage() {
   const { data: user } = useCurrentUser();
 
   const [error, setError] = useState(false);
+  const [freshLessonRequestKey, setFreshLessonRequestKey] = useState<string | null>(null);
+
+  const lessonRequestKey = `${lessonId}:${language}:${user?.id ?? ""}`;
 
   const {
     data: lesson,
@@ -55,6 +58,26 @@ export default function LessonPage() {
     isError: lessonError,
   } = useLesson(lessonId, language, user?.id || "");
   const { data: course } = useCourse(courseId, language);
+
+  useEffect(() => {
+    let isCurrentRequest = true;
+
+    setFreshLessonRequestKey(null);
+
+    void queryClient
+      .fetchQuery({
+        ...lessonQueryOptions(lessonId, language, user?.id ?? ""),
+        staleTime: 0,
+      })
+      .then(() => {
+        if (isCurrentRequest) setFreshLessonRequestKey(lessonRequestKey);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      isCurrentRequest = false;
+    };
+  }, [language, lessonId, lessonRequestKey, user?.id]);
 
   useEffect(() => {
     if (!lesson?.id || !courseId) return;
@@ -85,7 +108,9 @@ export default function LessonPage() {
     );
   }
 
-  if (!lesson || !course) {
+  const isLessonReady = lesson?.id === lessonId && freshLessonRequestKey === lessonRequestKey;
+
+  if (!isLessonReady || !course) {
     const targetLessonType = course?.chapters
       .flatMap((chapter) => chapter.lessons)
       .find((courseLesson) => courseLesson.id === lessonId)?.type;
@@ -205,6 +230,7 @@ export default function LessonPage() {
                 </p>
               </div>
               <LessonContent
+                key={lesson.id}
                 lesson={lesson}
                 course={course}
                 lessonsAmount={currentChapter?.lessons.length ?? 0}

--- a/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContent.tsx
@@ -9,6 +9,7 @@ import { Icon } from "~/components/Icon";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip";
+import { pauseAllLessonVideos, resumeLessonVideo } from "~/components/VideoPlayer/Video";
 import { useLessonsSequence } from "~/hooks/useLessonsSequence";
 import { LessonType } from "~/modules/Admin/EditCourse/EditCourse.types";
 import { useCourseAccessProvider } from "~/modules/Courses/context/CourseAccessProvider";
@@ -20,6 +21,7 @@ import { LEARNING_HANDLES } from "../../../../e2e/data/learning/handles";
 import { LessonContentRenderer } from "./LessonContentRenderer";
 import { LessonVideoProgressStrip } from "./LessonVideoProgressStrip";
 import { createLessonVideoProgressStore } from "./LessonVideoProgressStrip.utils";
+import { RequiredVideoLeaveGuard } from "./RequiredVideoLeaveGuard";
 import { isNextBlocked, isPreviousBlocked } from "./utils";
 
 import type { GetCourseResponse, GetLessonByIdResponse } from "~/api/generated-api";
@@ -75,6 +77,7 @@ export const LessonContent = ({
       showCoverageMarkers: videoProgressPersistenceEnabled && videoCompletionTrackingEnabled,
       lessonId: lesson.id,
       language,
+      onVideoActivated: videoProgressStore.getState().markVideoActivated,
       onSnapshotChange: videoProgressStore.getState().publishSnapshot,
     }),
     [
@@ -301,7 +304,20 @@ export const LessonContent = ({
             lessonId={lesson.id}
             description={lesson.description}
             enabled={shouldUseCoverageCompletion}
+            showRequirementWarning={!lesson.lessonCompleted}
             store={videoProgressStore}
+          />
+
+          <RequiredVideoLeaveGuard
+            courseId={course.id}
+            userId={user?.id ?? ""}
+            lessonCompleted={Boolean(lesson.lessonCompleted)}
+            enabled={shouldUseCoverageCompletion}
+            store={videoProgressStore}
+            onPause={pauseAllLessonVideos}
+            onContinueWatching={(resourceEntityId) => {
+              if (resourceEntityId) resumeLessonVideo(resourceEntityId);
+            }}
           />
 
           <LessonContentRenderer

--- a/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonContentRenderer.tsx
@@ -28,6 +28,7 @@ type LessonContentRendererProps = {
     lessonId: string;
     language: SupportedLanguages;
     onSnapshotChange?: (change: VideoCoverageSnapshotChange) => void;
+    onVideoActivated?: (resourceEntityId: string) => void;
   };
 };
 

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
@@ -1,7 +1,9 @@
+import { Info } from "lucide-react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 
+import { Alert, AlertDescription } from "~/components/ui/alert";
 import { cn } from "~/lib/utils";
 
 import {
@@ -18,6 +20,7 @@ export const LessonVideoProgressStrip = ({
   lessonId,
   description,
   enabled,
+  showRequirementWarning = true,
   store,
 }: LessonVideoProgressStripProps) => {
   const { t } = useTranslation();
@@ -96,6 +99,18 @@ export const LessonVideoProgressStrip = ({
           );
         })}
       </div>
+      {showRequirementWarning && (
+        <Alert className="flex items-center mt-4 gap-3 border-warning-200 bg-warning-50 px-3 py-2.5 text-warning-950 [&>svg]:static [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-warning-600 [&>svg~*]:pl-0 [&>svg+div]:translate-y-0">
+          <Info aria-hidden="true" />
+          <AlertDescription className="text-sm font-medium text-warning-950">
+            {t(
+              segments.length === 1
+                ? "studentLessonView.videoProgress.requirementSingle"
+                : "studentLessonView.videoProgress.requirementMultiple",
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
     </div>
   );
 };

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.tsx
@@ -100,9 +100,9 @@ export const LessonVideoProgressStrip = ({
         })}
       </div>
       {showRequirementWarning && (
-        <Alert className="flex items-center mt-4 gap-3 border-warning-200 bg-warning-50 px-3 py-2.5 text-warning-950 [&>svg]:static [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-warning-600 [&>svg~*]:pl-0 [&>svg+div]:translate-y-0">
+        <Alert className="flex items-center mt-4 gap-3 border-primary-200 bg-primary-50 px-3 py-2.5 text-primary-950 [&>svg]:static [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-primary-600 [&>svg~*]:pl-0 [&>svg+div]:translate-y-0">
           <Info aria-hidden="true" />
-          <AlertDescription className="text-sm font-medium text-warning-950">
+          <AlertDescription className="text-sm font-medium text-primary-950">
             {t(
               segments.length === 1
                 ? "studentLessonView.videoProgress.requirementSingle"

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.types.ts
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.types.ts
@@ -20,12 +20,15 @@ export type LessonVideoProgressStripProps = {
   lessonId: string;
   description: string | null;
   enabled: boolean;
+  showRequirementWarning?: boolean;
   store: LessonVideoProgressStore;
 };
 
 export type LessonVideoProgressStoreState = {
   segments: LessonVideoProgressSegment[];
+  lastActiveResourceEntityId: string | null;
   publishSnapshot: (change: LessonVideoProgressSnapshotChange) => void;
+  markVideoActivated: (resourceEntityId: string) => void;
   reset: (segments: LessonVideoProgressSegment[]) => void;
 };
 

--- a/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.utils.ts
+++ b/apps/web/app/modules/Courses/Lesson/LessonVideoProgressStrip.utils.ts
@@ -10,6 +10,7 @@ import type {
   LessonVideoProgressStore,
   LessonVideoProgressStoreState,
 } from "./LessonVideoProgressStrip.types";
+import type { VideoCoverageSnapshot } from "~/components/VideoPlayer/videoCoverage.types";
 
 export const VIDEO_COMPLETION_COVERAGE_THRESHOLD = 0.9;
 
@@ -51,17 +52,44 @@ export const applyLessonVideoProgressSnapshotChange = (
   segments.map((segment) => {
     if (segment.resourceEntityId !== progressChange.resourceEntityId) return segment;
 
+    const watchedRanges = mergeVideoCoverageRanges([
+      ...segment.watchedRanges,
+      ...progressChange.snapshot.watchedRanges,
+    ]);
+
     return {
       ...segment,
-      coveragePercent: clampVideoProgress(progressChange.snapshot.coveragePercent),
-      isWatched: progressChange.snapshot.isWatched,
-      watchedRanges: mergeVideoCoverageRanges(progressChange.snapshot.watchedRanges),
-      durationSeconds: progressChange.snapshot.durationSeconds,
+      coveragePercent: Math.max(
+        clampVideoProgress(segment.coveragePercent),
+        clampVideoProgress(progressChange.snapshot.coveragePercent),
+      ),
+      isWatched: segment.isWatched || progressChange.snapshot.isWatched,
+      watchedRanges,
+      durationSeconds: progressChange.snapshot.durationSeconds ?? segment.durationSeconds,
     };
   });
 
 export const isLessonVideoProgressSegmentComplete = (segment: LessonVideoProgressSegment) =>
   segment.isWatched || segment.coveragePercent >= VIDEO_COMPLETION_COVERAGE_THRESHOLD;
+
+export const hasStartedLessonVideo = (segment: LessonVideoProgressSegment) =>
+  segment.coveragePercent > 0 || segment.watchedRanges.length > 0;
+
+export const getLessonVideoResumeTarget = (
+  segments: LessonVideoProgressSegment[],
+  lastActiveResourceEntityId: string | null,
+) => {
+  const incomplete = segments.filter((segment) => !isLessonVideoProgressSegmentComplete(segment));
+  const lastActive = incomplete.find(
+    (segment) => segment.resourceEntityId === lastActiveResourceEntityId,
+  );
+  if (lastActive?.resourceEntityId) return lastActive.resourceEntityId;
+
+  const started = incomplete.find(hasStartedLessonVideo);
+  if (started?.resourceEntityId) return started.resourceEntityId;
+
+  return incomplete.find((segment) => segment.resourceEntityId)?.resourceEntityId ?? null;
+};
 
 export const getFallbackDurationSeconds = (watchedRanges: VideoCoverageRange[]) => {
   const maxEnd = watchedRanges.reduce((duration, [, end]) => Math.max(duration, end), 0);
@@ -105,6 +133,29 @@ export const getLessonVideoProgressRangeStyle = ({
 export const createLessonVideoProgressStore = (): LessonVideoProgressStore => {
   const progressChangesByResourceId = new Map<string, LessonVideoProgressSnapshotChange>();
 
+  const mergeSnapshotChange = (
+    previous: LessonVideoProgressSnapshotChange | undefined,
+    next: LessonVideoProgressSnapshotChange,
+  ): LessonVideoProgressSnapshotChange => {
+    if (!previous) return next;
+
+    const snapshot: VideoCoverageSnapshot = {
+      ...next.snapshot,
+      coveragePercent: Math.max(
+        clampVideoProgress(previous.snapshot.coveragePercent),
+        clampVideoProgress(next.snapshot.coveragePercent),
+      ),
+      isWatched: previous.snapshot.isWatched || next.snapshot.isWatched,
+      watchedRanges: mergeVideoCoverageRanges([
+        ...previous.snapshot.watchedRanges,
+        ...next.snapshot.watchedRanges,
+      ]),
+      durationSeconds: next.snapshot.durationSeconds ?? previous.snapshot.durationSeconds,
+    };
+
+    return { ...next, snapshot };
+  };
+
   const applyStoredProgressChanges = (nextSegments: LessonVideoProgressSegment[]) => {
     return Array.from(progressChangesByResourceId.values()).reduce(
       (currentSegments, progressChange) =>
@@ -115,12 +166,18 @@ export const createLessonVideoProgressStore = (): LessonVideoProgressStore => {
 
   return createStore<LessonVideoProgressStoreState>((set) => ({
     segments: [],
+    lastActiveResourceEntityId: null,
     publishSnapshot: (change) => {
-      progressChangesByResourceId.set(change.resourceEntityId, change);
+      const mergedChange = mergeSnapshotChange(
+        progressChangesByResourceId.get(change.resourceEntityId),
+        change,
+      );
+      progressChangesByResourceId.set(change.resourceEntityId, mergedChange);
       set((state) => ({
-        segments: applyLessonVideoProgressSnapshotChange(state.segments, change),
+        segments: applyLessonVideoProgressSnapshotChange(state.segments, mergedChange),
       }));
     },
+    markVideoActivated: (resourceEntityId) => set({ lastActiveResourceEntityId: resourceEntityId }),
     reset: (nextSegments) => {
       set({ segments: applyStoredProgressChanges(nextSegments) });
     },

--- a/apps/web/app/modules/Courses/Lesson/RequiredVideoLeaveGuard.tsx
+++ b/apps/web/app/modules/Courses/Lesson/RequiredVideoLeaveGuard.tsx
@@ -1,0 +1,143 @@
+import { useBlocker } from "@remix-run/react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+
+import {
+  getLessonVideoResumeTarget,
+  hasStartedLessonVideo,
+} from "./LessonVideoProgressStrip.utils";
+import {
+  getRequiredVideoLeavePreferenceKey,
+  useRequiredVideoLeavePreferenceStore,
+} from "./requiredVideoLeavePreferenceStore";
+
+import type { LessonVideoProgressStore } from "./LessonVideoProgressStrip.types";
+
+const BLOCKER_STATES = {
+  BLOCKED: "blocked",
+} as const;
+
+type RequiredVideoLeaveGuardProps = {
+  courseId: string;
+  userId: string;
+  lessonCompleted: boolean;
+  enabled: boolean;
+  store: LessonVideoProgressStore;
+  onPause: () => void;
+  onContinueWatching: (resourceEntityId: string | null) => void;
+};
+
+export const RequiredVideoLeaveGuard = ({
+  courseId,
+  userId,
+  lessonCompleted,
+  enabled,
+  store,
+  onPause,
+  onContinueWatching,
+}: RequiredVideoLeaveGuardProps) => {
+  const { t } = useTranslation();
+
+  const segments = useStore(store, (state) => state.segments);
+  const lastActiveResourceEntityId = useStore(store, (state) => state.lastActiveResourceEntityId);
+  const dismissed = useRequiredVideoLeavePreferenceStore(
+    (state) => state.dismissed[getRequiredVideoLeavePreferenceKey(userId, courseId)] ?? false,
+  );
+  const dismissForCourse = useRequiredVideoLeavePreferenceStore((state) => state.dismissForCourse);
+
+  const [rememberDecision, setRememberDecision] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const hasStartedVideo = segments.some(hasStartedLessonVideo);
+  const shouldBlock = enabled && !lessonCompleted && hasStartedVideo && !dismissed;
+
+  const blocker = useBlocker(shouldBlock);
+  const previousBlockerStateRef = useRef(blocker.state);
+
+  useEffect(() => {
+    const becameBlocked =
+      blocker.state === BLOCKER_STATES.BLOCKED &&
+      previousBlockerStateRef.current !== BLOCKER_STATES.BLOCKED;
+    previousBlockerStateRef.current = blocker.state;
+
+    if (!becameBlocked) return;
+
+    onPause();
+    setRememberDecision(false);
+    setIsDialogOpen(true);
+  }, [blocker.state, onPause]);
+
+  const remember = () => {
+    if (!rememberDecision) return;
+    dismissForCourse(getRequiredVideoLeavePreferenceKey(userId, courseId));
+  };
+
+  const exitAnyway = () => {
+    remember();
+    blocker.proceed?.();
+    setIsDialogOpen(false);
+  };
+
+  const continueWatching = () => {
+    remember();
+    blocker.reset?.();
+    onContinueWatching(getLessonVideoResumeTarget(segments, lastActiveResourceEntityId));
+    setIsDialogOpen(false);
+  };
+
+  return (
+    <Dialog
+      open={isDialogOpen}
+      onOpenChange={(open) => {
+        if (!open && blocker.state === BLOCKER_STATES.BLOCKED) {
+          exitAnyway();
+          return;
+        }
+        setIsDialogOpen(open);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("studentLessonView.requiredVideoLeave.title")}</DialogTitle>
+          <DialogDescription>
+            {t(
+              segments.length === 1
+                ? "studentLessonView.requiredVideoLeave.descriptionSingle"
+                : "studentLessonView.requiredVideoLeave.descriptionMultiple",
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center gap-2 text-sm text-neutral-700">
+          <Checkbox
+            id="required-video-leave-dismiss"
+            checked={rememberDecision}
+            onCheckedChange={(checked) => setRememberDecision(checked === true)}
+          />
+          <label htmlFor="required-video-leave-dismiss">
+            {t("studentLessonView.requiredVideoLeave.remember")}
+          </label>
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={exitAnyway}>
+            {t("studentLessonView.requiredVideoLeave.exitAnyway")}
+          </Button>
+          <Button type="button" onClick={continueWatching}>
+            {t("studentLessonView.requiredVideoLeave.continueWatching")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/web/app/modules/Courses/Lesson/__tests__/LessonVideoProgressStrip.test.tsx
+++ b/apps/web/app/modules/Courses/Lesson/__tests__/LessonVideoProgressStrip.test.tsx
@@ -6,6 +6,8 @@ import { renderWith } from "~/utils/testUtils";
 import { LessonVideoProgressStrip } from "../LessonVideoProgressStrip";
 import {
   createLessonVideoProgressStore,
+  getLessonVideoResumeTarget,
+  hasStartedLessonVideo,
   parseLessonVideoProgressSegments,
 } from "../LessonVideoProgressStrip.utils";
 
@@ -38,6 +40,14 @@ const lessonDescription = `
 `;
 
 describe("LessonVideoProgressStrip", () => {
+  it("selects the latest active incomplete video before earlier started videos", () => {
+    const segments = parseLessonVideoProgressSegments(lessonDescription);
+
+    expect(getLessonVideoResumeTarget(segments, "resource-one")).toBe("resource-one");
+    expect(getLessonVideoResumeTarget(segments, "resource-two")).toBe("resource-one");
+    expect(segments.some(hasStartedLessonVideo)).toBe(true);
+  });
+
   it("parses one segment per video node with watched range metadata", () => {
     expect(parseLessonVideoProgressSegments(lessonDescription)).toMatchObject([
       {
@@ -80,6 +90,7 @@ describe("LessonVideoProgressStrip", () => {
 
     expect(screen.getByText("Video progress")).toBeInTheDocument();
     expect(screen.getByText("1 of 3 completed")).toBeInTheDocument();
+    expect(screen.getByText("Watch all videos to complete this lesson.")).toBeInTheDocument();
     expect(progressBars[0]).toHaveAttribute("aria-valuenow", "30");
     expect(progressBars[0].querySelectorAll(".bg-primary-600")).toHaveLength(2);
     expect(progressBars[1]).toHaveAttribute("aria-valuenow", "90");
@@ -149,5 +160,48 @@ describe("LessonVideoProgressStrip", () => {
     await waitFor(() =>
       expect(screen.getAllByRole("progressbar")[0]).toHaveAttribute("aria-valuenow", "95"),
     );
+  });
+
+  it("does not erase live progress when a stale empty snapshot arrives", async () => {
+    const store = createLessonVideoProgressStore();
+
+    renderWith().render(
+      <LessonVideoProgressStrip
+        lessonId="lesson-id"
+        description={lessonDescription}
+        enabled
+        store={store}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getAllByRole("progressbar")).toHaveLength(3));
+
+    act(() => {
+      store.getState().publishSnapshot({
+        resourceEntityId: "resource-one",
+        snapshot: {
+          coveragePercent: 0.5,
+          watchedRanges: [[0, 50]],
+          isWatched: false,
+          durationSeconds: 100,
+          bucketSizeSeconds: 1,
+        },
+      });
+      store.getState().publishSnapshot({
+        resourceEntityId: "resource-one",
+        snapshot: {
+          coveragePercent: 0,
+          watchedRanges: [],
+          isWatched: false,
+          durationSeconds: null,
+          bucketSizeSeconds: 1,
+        },
+      });
+    });
+
+    expect(screen.getAllByRole("progressbar")[0]).toHaveAttribute("aria-valuenow", "50");
+    expect(
+      screen.getAllByRole("progressbar")[0].querySelector(".bg-primary-600"),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/app/modules/Courses/Lesson/requiredVideoLeavePreferenceStore.ts
+++ b/apps/web/app/modules/Courses/Lesson/requiredVideoLeavePreferenceStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type RequiredVideoLeavePreferenceState = {
+  dismissed: Record<string, true>;
+  dismissForCourse: (key: string) => void;
+};
+
+export const getRequiredVideoLeavePreferenceKey = (userId: string, courseId: string) =>
+  `${userId}:${courseId}`;
+
+export const useRequiredVideoLeavePreferenceStore = create<RequiredVideoLeavePreferenceState>()(
+  persist(
+    (set) => ({
+      dismissed: {},
+      dismissForCourse: (key) =>
+        set((state) => ({ dismissed: { ...state.dismissed, [key]: true } })),
+    }),
+    { name: "required-video-leave-preferences" },
+  ),
+);

--- a/apps/web/app/modules/Dashboard/Settings/Settings.page.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/Settings.page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { useCurrentUser } from "~/api/queries";
 import { useConfigurationState } from "~/api/queries/admin/useConfigurationState";
+import { useMicrosoftCalendarConnection } from "~/api/queries/calendar/useMicrosoftCalendarConnection";
 import { useGlobalSettings } from "~/api/queries/useGlobalSettings";
 import { useUserSettings } from "~/api/queries/useUserSettings";
 import { hasAnyPermission, hasPermission } from "~/common/permissions/permission.utils";
@@ -55,6 +56,7 @@ export default function SettingsPage() {
   const isSupportMode = Boolean(user?.isSupportMode);
   const { data: userSettings, isLoading: isLoadingUserSettings } = useUserSettings(!isSupportMode);
   const { data: globalSettings, isLoading: isLoadingGlobalSettings } = useGlobalSettings();
+  const { data: microsoftCalendarConnection } = useMicrosoftCalendarConnection(!isSupportMode);
   const { data: configurationState } = useConfigurationState({
     enabled: canManageEnvs,
   });
@@ -82,6 +84,8 @@ export default function SettingsPage() {
 
   const hasConfigurationIssues =
     canManageEnvs && configurationState?.hasIssues && !configurationState?.isWarningDismissed;
+  const hasIntegrationsAvailable =
+    canManageIntegrationApi || Boolean(microsoftCalendarConnection?.available);
 
   return (
     <PageWrapper
@@ -99,6 +103,7 @@ export default function SettingsPage() {
           canManageSettings={canManageSettings}
           isSupportMode={isSupportMode}
           hideAccountTab={isSupportMode}
+          hasIntegrationsAvailable={hasIntegrationsAvailable}
           hasConfigurationIssues={hasConfigurationIssues}
           accountContent={
             !isSupportMode && (

--- a/apps/web/app/modules/Dashboard/Settings/components/SettingsNavigationTabs.tsx
+++ b/apps/web/app/modules/Dashboard/Settings/components/SettingsNavigationTabs.tsx
@@ -20,6 +20,7 @@ interface SettingsNavigationTabsProps {
   organizationContent?: React.ReactNode;
   customizePlatformContent?: React.ReactNode;
   hasConfigurationIssues?: boolean;
+  hasIntegrationsAvailable?: boolean;
 }
 
 export function SettingsNavigationTabs({
@@ -31,6 +32,7 @@ export function SettingsNavigationTabs({
   organizationContent,
   customizePlatformContent,
   hasConfigurationIssues,
+  hasIntegrationsAvailable = true,
 }: SettingsNavigationTabsProps) {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -47,7 +49,7 @@ export function SettingsNavigationTabs({
     ...(!hideAccountTab
       ? [{ value: SETTINGS_TABS.ACCOUNT, label: t("settings.tabs.account") }]
       : []),
-    ...(!hideAccountTab
+    ...(!hideAccountTab && hasIntegrationsAvailable
       ? [{ value: SETTINGS_TABS.INTEGRATIONS, label: t("settings.tabs.integrations") }]
       : []),
     ...(canManageSettings ? adminTabs : []),
@@ -132,13 +134,15 @@ export function SettingsNavigationTabs({
             </TabsContent>
           )}
 
-          <TabsContent
-            value={SETTINGS_TABS.INTEGRATIONS}
-            className="space-y-6"
-            data-testid={SETTINGS_PAGE_HANDLES.INTEGRATIONS_CONTENT}
-          >
-            {integrationsContent}
-          </TabsContent>
+          {hasIntegrationsAvailable && (
+            <TabsContent
+              value={SETTINGS_TABS.INTEGRATIONS}
+              className="space-y-6"
+              data-testid={SETTINGS_PAGE_HANDLES.INTEGRATIONS_CONTENT}
+            >
+              {integrationsContent}
+            </TabsContent>
+          )}
 
           <TabsContent
             value={SETTINGS_TABS.ORGANIZATION}

--- a/apps/web/e2e/fixtures/auth.actions.ts
+++ b/apps/web/e2e/fixtures/auth.actions.ts
@@ -1,9 +1,37 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type BrowserContext, type Page } from "@playwright/test";
 
 import { LOGIN_PAGE_HANDLES } from "../data/auth/handles";
 import { NAVIGATION_HANDLES } from "../data/navigation/handles";
 
 const LOGIN_URL = "/auth/login";
+
+export async function authenticateContext(
+  context: BrowserContext,
+  origin: string,
+  email: string,
+  password: string,
+) {
+  await context.clearCookies();
+
+  const response = await context.request.post(`${origin}/api/auth/login`, {
+    data: { email, password },
+    headers: {
+      Origin: origin,
+      Referer: `${origin}/`,
+    },
+  });
+
+  expect(response, `API login failed for ${email}`).toBeOK();
+
+  const currentUserResponse = await context.request.get(`${origin}/api/auth/current-user`, {
+    headers: {
+      Origin: origin,
+      Referer: `${origin}/`,
+    },
+  });
+
+  expect(currentUserResponse, `Authenticated user could not be loaded for ${email}`).toBeOK();
+}
 
 export async function login(
   page: Page,

--- a/apps/web/e2e/fixtures/test.fixture.ts
+++ b/apps/web/e2e/fixtures/test.fixture.ts
@@ -24,7 +24,7 @@ import { extractLinkFromMailhogMessage, waitForMailhogMessage } from "../utils/m
 import { markAllOnboardingComplete } from "../utils/onboarding";
 import { buildLmsLocalhostTenantHost } from "../utils/tenant-host";
 
-import { login } from "./auth.actions";
+import { authenticateContext, login } from "./auth.actions";
 import { cleanupFixture } from "./cleanup.fixture";
 import { factoryFixture } from "./factory.fixture";
 import { pageFixture } from "./page.fixture";
@@ -91,6 +91,7 @@ export type TenantUserHandle = {
 };
 
 type WorkerTenantWorkspace = {
+  apiClient: FixtureApiClient;
   authStatePaths: Record<UserRole, string>;
   origin: string;
   tenant: TenantFactoryRecord;
@@ -257,9 +258,9 @@ const writeWorkerAuthState = async (
   try {
     if (origin) await addWorkspaceInitScript(context, origin);
 
-    const page = await context.newPage();
-    await login(page, email, ACCOUNT_PASSWORD, origin ? { origin } : undefined);
-    await apiClient.syncFromContext(context, origin ?? new URL(page.url()).origin);
+    const authOrigin = origin ?? new URL(DEFAULT_BASE_URL).origin;
+    await authenticateContext(context, authOrigin, email, ACCOUNT_PASSWORD);
+    await apiClient.syncFromContext(context, authOrigin);
     await markAllOnboardingComplete(apiClient);
     await context.storageState({ path });
   } finally {
@@ -318,6 +319,7 @@ export const test = mergedFixture.extend<
   {
     createWorkspaceContext: CreateWorkspaceContext;
     createWorkspacePage: CreateWorkspacePage;
+    workerTenantApiClient: FixtureApiClient;
     withReadonlyPage: WithAuthPage;
     withWorkerPage: WithAuthPage;
     createIsolatedWorkspace: CreateIsolatedWorkspace;
@@ -325,7 +327,7 @@ export const test = mergedFixture.extend<
   },
   {
     _ensureWorkerAuthReady: () => Promise<void>;
-    _getWorkerTenantWorkspace: () => Promise<WorkerTenantWorkspace>;
+    _getWorkerTenantWorkspace: WorkerTenantWorkspace;
   }
 >({
   _ensureWorkerAuthReady: [
@@ -337,12 +339,11 @@ export const test = mergedFixture.extend<
           const apiClient = createFixtureApiClient();
           const origin = new URL(DEFAULT_BASE_URL).origin;
           const adminContext = await browser.newContext({ baseURL: origin });
-          const adminPage = await adminContext.newPage();
           const workerAuthStates: { email: string; path: string }[] = [];
 
           try {
             await addWorkspaceInitScript(adminContext, origin);
-            await login(adminPage, ADMIN_EMAIL, ADMIN_PASSWORD, { origin });
+            await authenticateContext(adminContext, origin, ADMIN_EMAIL, ADMIN_PASSWORD);
 
             await apiClient.syncFromContext(adminContext, origin);
 
@@ -373,21 +374,21 @@ export const test = mergedFixture.extend<
   ],
   _getWorkerTenantWorkspace: [
     async ({ browser }, use, workerInfo) => {
-      let setupPromise: Promise<WorkerTenantWorkspace> | undefined;
       let cleanupApiClient: FixtureApiClient | undefined;
       let tenant: TenantFactoryRecord | undefined;
+      let workerTenantApiClient: FixtureApiClient | undefined;
 
-      await use(async () => {
-        setupPromise ??= (async () => {
+      try {
+        const workerTenantWorkspace = await (async () => {
           const origin = new URL(DEFAULT_BASE_URL).origin;
           const adminContext = await browser.newContext({ baseURL: origin });
-          const adminPage = await adminContext.newPage();
           const apiClient = createFixtureApiClient();
+          workerTenantApiClient = apiClient;
           cleanupApiClient = createFixtureApiClient();
 
           try {
             await addWorkspaceInitScript(adminContext, origin);
-            await login(adminPage, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await authenticateContext(adminContext, origin, ADMIN_EMAIL, ADMIN_PASSWORD);
             await apiClient.syncFromContext(adminContext, origin);
             await cleanupApiClient.syncFromContext(adminContext, origin);
 
@@ -420,12 +421,14 @@ export const test = mergedFixture.extend<
 
             const tenantAdminContext = await browser.newContext({ baseURL: workspaceOrigin });
             await addWorkspaceInitScript(tenantAdminContext, workspaceOrigin);
-            const tenantAdminPage = await tenantAdminContext.newPage();
 
             try {
-              await login(tenantAdminPage, tenantAdminEmail, tenantAdminPassword, {
-                origin: workspaceOrigin,
-              });
+              await authenticateContext(
+                tenantAdminContext,
+                workspaceOrigin,
+                tenantAdminEmail,
+                tenantAdminPassword,
+              );
               await apiClient.syncFromContext(tenantAdminContext, workspaceOrigin);
               await markAllOnboardingComplete(apiClient);
 
@@ -446,6 +449,7 @@ export const test = mergedFixture.extend<
               }
 
               return {
+                apiClient,
                 authStatePaths,
                 origin: workspaceOrigin,
                 tenant,
@@ -454,22 +458,23 @@ export const test = mergedFixture.extend<
               await tenantAdminContext.close();
             }
           } finally {
-            apiClient.clearCookies();
             await adminContext.close();
           }
         })();
 
-        return setupPromise;
-      });
+        await use(workerTenantWorkspace);
+      } finally {
+        workerTenantApiClient?.clearCookies();
 
-      if (cleanupApiClient) {
-        if (tenant) {
-          const cleanupTenantFactory =
-            createFixtureFactories(cleanupApiClient).createTenantFactory();
-          await cleanupTenantFactory.deactivate(tenant.id);
+        if (cleanupApiClient) {
+          if (tenant) {
+            const cleanupTenantFactory =
+              createFixtureFactories(cleanupApiClient).createTenantFactory();
+            await cleanupTenantFactory.deactivate(tenant.id);
+          }
+
+          cleanupApiClient.clearCookies();
         }
-
-        cleanupApiClient.clearCookies();
       }
     },
     { scope: "worker", timeout: 120 * 1000 },
@@ -479,7 +484,7 @@ export const test = mergedFixture.extend<
       _getWorkerTenantWorkspace,
       browser,
     }: {
-      _getWorkerTenantWorkspace: () => Promise<WorkerTenantWorkspace>;
+      _getWorkerTenantWorkspace: WorkerTenantWorkspace;
       browser: Browser;
     },
     use: (value: CreateWorkspaceContext) => Promise<void>,
@@ -487,7 +492,7 @@ export const test = mergedFixture.extend<
     await use(async (options = {}) => {
       const origin = options.root
         ? new URL(DEFAULT_BASE_URL).origin
-        : (await _getWorkerTenantWorkspace()).origin;
+        : _getWorkerTenantWorkspace.origin;
       const context = await createWorkspaceBrowserContext(browser, origin, options);
 
       return { context, origin };
@@ -508,6 +513,9 @@ export const test = mergedFixture.extend<
       return { context, origin, page };
     });
   },
+  workerTenantApiClient: async ({ _getWorkerTenantWorkspace }, use) => {
+    await use(_getWorkerTenantWorkspace.apiClient);
+  },
   withWorkerPage: async (
     {
       _ensureWorkerAuthReady,
@@ -516,7 +524,7 @@ export const test = mergedFixture.extend<
       browser,
     }: {
       _ensureWorkerAuthReady: () => Promise<void>;
-      _getWorkerTenantWorkspace: () => Promise<WorkerTenantWorkspace>;
+      _getWorkerTenantWorkspace: WorkerTenantWorkspace;
       apiClient: FixtureApiClient;
       browser: Browser;
     },
@@ -549,17 +557,20 @@ export const test = mergedFixture.extend<
           return;
         }
 
-        const workerTenantWorkspace = await _getWorkerTenantWorkspace();
-        const context = await createWorkspaceBrowserContext(browser, workerTenantWorkspace.origin, {
-          storageState: workerTenantWorkspace.authStatePaths[role],
-        });
+        const context = await createWorkspaceBrowserContext(
+          browser,
+          _getWorkerTenantWorkspace.origin,
+          {
+            storageState: _getWorkerTenantWorkspace.authStatePaths[role],
+          },
+        );
 
         try {
           const page = await context.newPage();
 
-          await apiClient.syncFromContext(context, workerTenantWorkspace.origin);
+          await apiClient.syncFromContext(context, _getWorkerTenantWorkspace.origin);
 
-          await run({ context, origin: workerTenantWorkspace.origin, page });
+          await run({ context, origin: _getWorkerTenantWorkspace.origin, page });
         } finally {
           await context.close();
         }

--- a/apps/web/e2e/specs/news/news-test.fixture.ts
+++ b/apps/web/e2e/specs/news/news-test.fixture.ts
@@ -1,14 +1,10 @@
-import { USER_ROLE } from "~/config/userRoles";
-
 import { test as base } from "../../fixtures/test.fixture";
 import { ensureNewsModuleEnabled } from "../../utils/content-features";
 
 export const test = base.extend<{ _newsEnabled: void }>({
   _newsEnabled: [
-    async ({ apiClient, withWorkerPage }, use) => {
-      await withWorkerPage(USER_ROLE.admin, async () => {
-        await ensureNewsModuleEnabled(apiClient);
-      });
+    async ({ workerTenantApiClient }, use) => {
+      await ensureNewsModuleEnabled(workerTenantApiClient);
 
       await use();
     },

--- a/docs/specs/lesson-delivery-learning-mode-business-spec.md
+++ b/docs/specs/lesson-delivery-learning-mode-business-spec.md
@@ -21,6 +21,8 @@ The main workflow starts when a learner opens a course and chooses to start or c
 - Render content, quiz, AI mentor, embed, SCORM, and live training lessons.
 - Control lesson videos with focused keyboard shortcuts for play, seeking, volume, mute, restart, and fullscreen.
 - Show watched and missed chunks across lesson videos when video completion tracking is enabled.
+- Warn learners before leaving an incomplete lesson with required video content and offer a direct way to continue watching.
+- Resume the most recently active incomplete video, or the next eligible incomplete video, from the saved watched position.
 - Navigate to previous and next lessons from the learner lesson page.
 - Enforce lesson sequencing when ordered completion is enabled.
 - Keep later lessons locked after unmet requirements, such as a failed required quiz.
@@ -43,6 +45,8 @@ Each lesson type has its own completion behavior. Content and embed lessons can 
 
 For content videos, opening the video focuses the player so learners can use familiar playback shortcuts while the player is active, without those shortcuts taking over the rest of the lesson page. When video completion tracking is enabled, the lesson also shows a segmented progress strip with one part per video, helping learners spot which parts they have watched and which parts they still missed. A video segment turns green after the learner has watched enough of that video to satisfy the completion threshold.
 
+When a required-video lesson has started but is not complete, Mentingo explains below the progress strip that the learner must watch the entire video or all videos. Leaving through in-app navigation opens a confirmation dialog with an option to exit or continue watching. Continue watching keeps the learner on the lesson, returns to the most recently active incomplete video, and resumes from the current or saved unwatched position. Learners can remember their decision for the course; the preference is kept locally for that learner and course.
+
 While the learner studies, the page also runs the learning-time tracker. Completion events update lesson, chapter, and course progress and can trigger downstream completion behavior such as certificates, reporting updates, and the course-finished notification. Those course-level side effects happen when the course changes from incomplete to completed; repeated saves or runtime commits do not create another completion notification. The course progress card shows completed and total chapter counts in the interface language.
 
 ## Key Technical Context
@@ -52,6 +56,7 @@ While the learner studies, the page also runs the learning-time tracker. Complet
 - Lesson rendering is centralized in `LessonContentRenderer`.
 - Rich-text lesson videos use the shared `VideoPlayer` component for playback controls, focused keyboard shortcuts, and watched-range tracking.
 - Video completion tracking stores watched ranges per lesson video and treats 90% watched coverage as completed.
+- The learner leave guard uses the existing watched-range snapshots and blocks only client-side navigation for incomplete required-video lessons.
 - Lesson access and progress updates use `PERMISSIONS.LEARNING_PROGRESS_UPDATE` and `PERMISSIONS.LEARNING_MODE_USE`.
 - Progress updates are handled through `apps/api/src/studentLessonProgress`.
 - Learning-time tracking uses `apps/web/app/hooks/useLearningTimeTracker.ts` and `apps/api/src/learning-time`.
@@ -60,4 +65,5 @@ While the learner studies, the page also runs the learning-time tracker. Complet
 
 - Web E2E coverage verifies starting learning, continuing to the next content lesson, opening lessons out of order when sequence is disabled, blocking skipped lessons when sequence is enabled, keeping the next lesson locked after a failed required quiz, submitting and retaking quizzes, completing embed lessons, accessing AI mentor entry points, and SCORM launch/resume/completion behavior.
 - Web unit coverage verifies the learning-mode reset from Statistics to the table of contents, the segmented lesson video progress strip, watched chunk rendering, 90% green completion state, and live updates from the video tracker.
+- Focused frontend coverage verifies the required-video warning, leave dialog actions and remembered preference, and resuming the selected video from its saved position.
 - API E2E coverage verifies quiz feedback visibility rules, lesson completion restrictions for authors/admins outside learning mode, admin/content-creator learning-mode behavior, quiz submission rules, quiz lesson deletion with submitted answers, and learning-time queue processing.

--- a/docs/specs/lesson-delivery-learning-mode-business-spec.md
+++ b/docs/specs/lesson-delivery-learning-mode-business-spec.md
@@ -41,11 +41,13 @@ Learning-time tracking adds another reporting signal, helping teams understand b
 
 The lesson page loads the selected course and lesson in the active content language. It shows the lesson content, chapter context, navigation controls, and the course lesson sidebar. When an administrator or content creator enters learning mode from the course overview, Mentingo returns the course panel to the table of contents so an admin-only Statistics tab cannot leave the learner view empty.
 
+Moving between lessons reloads the selected lesson's learner-specific state before its content is mounted. This keeps the progress strip and video resume position aligned with the latest saved watched ranges instead of briefly reusing another lesson's player state or an older cached response.
+
 Each lesson type has its own completion behavior. Content and embed lessons can complete when opened or when required video content finishes. Quiz lessons depend on quiz submission and passing rules. AI mentor, SCORM, and live training lessons use their own lesson-specific state. When sequence mode is enabled, Mentingo blocks access to later lessons until earlier lessons are complete.
 
 For content videos, opening the video focuses the player so learners can use familiar playback shortcuts while the player is active, without those shortcuts taking over the rest of the lesson page. When video completion tracking is enabled, the lesson also shows a segmented progress strip with one part per video, helping learners spot which parts they have watched and which parts they still missed. A video segment turns green after the learner has watched enough of that video to satisfy the completion threshold.
 
-When a required-video lesson has started but is not complete, Mentingo explains below the progress strip that the learner must watch the entire video or all videos. Leaving through in-app navigation opens a confirmation dialog with an option to exit or continue watching. Continue watching keeps the learner on the lesson, returns to the most recently active incomplete video, and resumes from the current or saved unwatched position. Learners can remember their decision for the course; the preference is kept locally for that learner and course.
+When a required-video lesson has started but is not complete, Mentingo explains below the progress strip that the learner must watch the entire video or all videos. Leaving through in-app navigation opens a confirmation dialog with an option to exit or continue watching. Continue watching keeps the learner on the lesson, returns to the most recently active incomplete video, and resumes from the current or saved unwatched position. Pausing after continuing stops coverage collection immediately, while any progress already watched is saved in order without a delayed background update. Learners can remember their decision for the course; the preference is kept locally for that learner and course.
 
 While the learner studies, the page also runs the learning-time tracker. Completion events update lesson, chapter, and course progress and can trigger downstream completion behavior such as certificates, reporting updates, and the course-finished notification. Those course-level side effects happen when the course changes from incomplete to completed; repeated saves or runtime commits do not create another completion notification. The course progress card shows completed and total chapter counts in the interface language.
 
@@ -55,7 +57,9 @@ While the learner studies, the page also runs the learning-time tracker. Complet
 - The route is `/course/:courseId/lesson/:lessonId`.
 - Lesson rendering is centralized in `LessonContentRenderer`.
 - Rich-text lesson videos use the shared `VideoPlayer` component for playback controls, focused keyboard shortcuts, and watched-range tracking.
-- Video completion tracking stores watched ranges per lesson video and treats 90% watched coverage as completed.
+- Video completion tracking stores watched ranges per lesson video, serializes overlapping pause saves, ignores paused or detached player instances, and treats 90% watched coverage as completed.
+- Courses without an explicitly stored video-completion setting use the enabled default consistently when lessons are read and progress is saved.
+- Creating or updating rich-text lessons synchronizes referenced file and video attachments; lesson delivery also repairs a missing attachment relation before returning learner progress metadata.
 - The learner leave guard uses the existing watched-range snapshots and blocks only client-side navigation for incomplete required-video lessons.
 - Lesson access and progress updates use `PERMISSIONS.LEARNING_PROGRESS_UPDATE` and `PERMISSIONS.LEARNING_MODE_USE`.
 - Progress updates are handled through `apps/api/src/studentLessonProgress`.


### PR DESCRIPTION
## Issue(s)

- #1935 

## Overview

Improves learner video-progress tracking and required-video navigation. Learners can resume incomplete videos from their saved position, see reliable progress on every lesson, and continue watching after a navigation warning without creating duplicate Video.js players or counting progress after pausing.

The change also repairs missing lesson/video resource relations, applies the enabled-by-default video tracking setting consistently, and cleans up aborted video file streams.

## Business Value

Learners return to the correct point in a lesson and receive trustworthy completion feedback. Required-video lessons no longer lose progress, regress visually, or continue recording watch time in the background. Reliable resource relations and stream cleanup reduce broken video playback and backend file-stream timeouts.

## Screenshots / Video

https://github.com/user-attachments/assets/e2e92ad9-7372-4aa0-9453-abab4dba8ebd

