### PR TITLE
chore: improve rich text styling in content lesson

### DIFF
--- a/apps/web/app/components/RichText/Viever.tsx
+++ b/apps/web/app/components/RichText/Viever.tsx
@@ -10,6 +10,7 @@ import {
   defaultClasses,
   contentVariantClasses,
 } from "./styles";
+import { normalizeMarkdownCode } from "./viewer.utils";
 import { RICH_TEXT_VIEWER_VARIANT, type RichTextViewerVariant } from "./viewerTypes";
 
 import type { SupportedLanguages } from "@repo/shared";
@@ -82,6 +83,7 @@ const Viewer = ({
 
   const editorClasses = cn(
     "h-full flex flex-col",
+    defaultClasses.codeBlock,
     defaultClasses.ul,
     defaultClasses.ol,
     defaultClasses.taskList,
@@ -99,10 +101,12 @@ const Viewer = ({
     );
   }, [handleVideoEnded, variant, videoCoverageTracking]);
 
+  const normalizedContent = useMemo(() => normalizeMarkdownCode(content), [content]);
+
   const editor = useEditor(
     {
       extensions,
-      content,
+      content: normalizedContent,
       editable: false,
       editorProps: {
         attributes: {
@@ -110,7 +114,7 @@ const Viewer = ({
         },
       },
     },
-    [content],
+    [normalizedContent],
   );
 
   if (!editor) return <></>;

--- a/apps/web/app/components/RichText/styles.ts
+++ b/apps/web/app/components/RichText/styles.ts
@@ -1,12 +1,32 @@
 export const defaultClasses = {
+  codeBlock: `
+      [&_pre]:my-3
+      [&_pre]:overflow-x-auto
+      [&_pre]:rounded-md
+      [&_pre]:bg-neutral-900
+      [&_pre]:p-4
+      [&_pre]:text-sm
+      [&_pre]:text-neutral-100
+      [&_pre_code]:bg-transparent
+      [&_pre_code]:p-0
+      [&_code:not(pre_code)]:rounded-sm
+      [&_code:not(pre_code)]:border
+      [&_code:not(pre_code)]:border-neutral-700
+      [&_code:not(pre_code)]:bg-neutral-800
+      [&_code:not(pre_code)]:px-1.5
+      [&_code:not(pre_code)]:py-0.5
+      [&_code:not(pre_code)]:font-mono
+      [&_code:not(pre_code)]:text-[0.9em]
+      [&_code:not(pre_code)]:text-neutral-100
+      [&_code:not(pre_code)]:before:content-none
+      [&_code:not(pre_code)]:after:content-none
+    `,
   ul: `
       [&>div>ul]:list-disc
       [&>div>ul]:pl-5
       [&>div>ul>li>p]:inline
       [&>div>ul>li>p]:text-neutral-900
-      
       [&>div>*]:!my-1
-      
       [&_ul]:list-disc
       [&_[contenteditable='true']>ul>li]:pl-0
       [&_[contenteditable='true']>ul>li_ul_li]:pl-4

--- a/apps/web/app/components/RichText/viewer.utils.test.ts
+++ b/apps/web/app/components/RichText/viewer.utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeMarkdownCode } from "./viewer.utils";
+
+describe("normalizeMarkdownCode", () => {
+  it("converts fenced Markdown into selectable HTML code blocks", () => {
+    const content = "Before\n\n```typescript\nconst answer = 42;\n```\n\nAfter";
+
+    expect(normalizeMarkdownCode(content)).toBe(
+      'Before\n\n<pre><code class="language-typescript">const answer = 42;</code></pre>\n\nAfter',
+    );
+  });
+
+  it("escapes HTML inside code blocks", () => {
+    expect(normalizeMarkdownCode("~~~html\n<div>safe</div>\n~~~")).toBe(
+      '<pre><code class="language-html">&lt;div&gt;safe&lt;/div&gt;</code></pre>',
+    );
+  });
+
+  it("leaves ordinary content unchanged", () => {
+    expect(normalizeMarkdownCode("Use ordinary content here.")).toBe("Use ordinary content here.");
+  });
+
+  it("converts inline Markdown code into a code element without backticks", () => {
+    expect(normalizeMarkdownCode("Use `Testingo` here.")).toBe("Use <code>Testingo</code> here.");
+  });
+});

--- a/apps/web/app/components/RichText/viewer.utils.ts
+++ b/apps/web/app/components/RichText/viewer.utils.ts
@@ -1,0 +1,23 @@
+import { escape } from "lodash-es";
+
+const INLINE_CODE_REGEX = /(?<!`)`([^`\n]+)`(?!`)/g;
+const FENCED_CODE_BLOCK_REGEX = /(^|\n)([ \t]*)(```|~~~)([^\n]*)\n([\s\S]*?)\n\2\3[ \t]*(?=\n|$)/g;
+
+const sanitizeLanguage = (language: string) =>
+  (language.trim().split(/\s+/u)[0] ?? "").replace(/[^a-z\d_-]/giu, "");
+
+export const normalizeMarkdownCode = (content: string) => {
+  const withFencedCodeBlocks = content.replace(
+    FENCED_CODE_BLOCK_REGEX,
+    (_match, prefix: string, indentation: string, fence: string, info: string, code: string) => {
+      const language = sanitizeLanguage(info);
+      const className = language ? ` class="language-${language}"` : "";
+
+      return `${prefix}${indentation}<pre><code${className}>${escape(code)}</code></pre>`;
+    },
+  );
+
+  return withFencedCodeBlocks.replace(INLINE_CODE_REGEX, (_match, code: string) => {
+    return `<code>${escape(code)}</code>`;
+  });
+};


### PR DESCRIPTION
## Issue(s)

- #1858

## Overview

Updated the rich-text viewer used by content lessons to render Markdown inline code and fenced code blocks as proper selectable HTML code elements. Added neutral, Slack-like styling for inline code and scrollable styling for fenced blocks. HTML inside code blocks is escaped safely, and regression tests cover the supported Markdown cases.

## Business Value

Learners can read and select technical examples naturally in content lessons instead of seeing raw accent graves and Markdown syntax. This improves readability and makes instructional code easier to copy and use.

## Screenshots / Video

<img width="974" height="398" alt="image" src="https://github.com/user-attachments/assets/358f2e82-0494-4951-a54b-ec75b27a4360" />
