### PR TITLE
chore: improve course access handling and refresh error page styling

### DIFF
--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -1389,6 +1389,8 @@ export class CourseService {
     userPermissions: PermissionKey[] = [],
     language: SupportedLanguages,
   ): Promise<CommonShowCourse> {
+    await this.ensureAnonymousCourseAccess(userId);
+
     const { courseId: id, slug: currentSlug } = match(
       await this.courseSlugService.getCourseIdBySlug(idOrSlug, language),
     )
@@ -1634,6 +1636,8 @@ export class CourseService {
     userId?: UUIDType,
     userPermissions: PermissionKey[] = [],
   ): Promise<CourseLookupResponse> {
+    await this.ensureAnonymousCourseAccess(userId);
+
     const lookupResult = await this.courseSlugService.getCourseIdBySlug(idOrSlug, language);
 
     if (lookupResult.type === "notFound") {
@@ -1695,6 +1699,16 @@ export class CourseService {
         slug: value.slug,
       }))
       .exhaustive();
+  }
+
+  private async ensureAnonymousCourseAccess(userId?: UUIDType) {
+    if (userId) return;
+
+    const globalSettings = await this.settingsService.getPublicGlobalSettings();
+
+    if (!globalSettings.unregisteredUserCoursesAccessibility) {
+      throw new NotFoundException("adminCourseView.errors.notFound.course");
+    }
   }
 
   async getBetaCourseById(
@@ -4050,6 +4064,7 @@ export class CourseService {
           categories.title,
           `%${filters.category}%`,
           language,
+          { baseTable: categories, fallbackToBaseLanguage: true },
         ),
       );
     }

--- a/apps/api/src/localization/localization.service.ts
+++ b/apps/api/src/localization/localization.service.ts
@@ -129,7 +129,23 @@ export class LocalizationService {
     fieldColumn: AnyPgColumn,
     pattern: string,
     language?: SupportedLanguages,
+    options: {
+      baseTable?: BaseTable;
+      fallbackToBaseLanguage?: boolean;
+    } = {},
   ) {
+    if (language && options.fallbackToBaseLanguage) {
+      if (!options.baseTable) {
+        throw new Error("baseTable is required when fallbackToBaseLanguage is enabled");
+      }
+
+      return sql`${this.getLocalizedSqlField(
+        fieldColumn,
+        language,
+        options.baseTable,
+      )} ilike ${pattern}`;
+    }
+
     if (language) return sql`${this.getFieldByLanguage(fieldColumn, language)} ilike ${pattern}`;
 
     return sql`

--- a/apps/web/app/api/queries/useCourse.ts
+++ b/apps/web/app/api/queries/useCourse.ts
@@ -13,9 +13,14 @@ export const getCourseQueryKey = (idOrSlug: string, language?: SupportedLanguage
   { id: idOrSlug, ...(language ? { language } : {}) },
 ];
 
-export const courseQueryOptions = (idOrSlug: string, language?: SupportedLanguages) =>
+export const courseQueryOptions = (
+  idOrSlug: string,
+  language?: SupportedLanguages,
+  enabled = true,
+) =>
   queryOptions({
     queryKey: getCourseQueryKey(idOrSlug, language),
+    enabled,
     queryFn: async () => {
       const response = await ApiClient.api.courseControllerGetCourse({
         id: idOrSlug ?? "",
@@ -26,8 +31,12 @@ export const courseQueryOptions = (idOrSlug: string, language?: SupportedLanguag
     select: (data: GetCourseResponse) => data.data,
   });
 
-export function useCourse(idOrSlug: string, language: SupportedLanguages = SUPPORTED_LANGUAGES.EN) {
-  return useQuery(courseQueryOptions(idOrSlug, language));
+export function useCourse(
+  idOrSlug: string,
+  language: SupportedLanguages = SUPPORTED_LANGUAGES.EN,
+  enabled = true,
+) {
+  return useQuery(courseQueryOptions(idOrSlug, language, enabled));
 }
 
 export function useCourseSuspense(

--- a/apps/web/app/api/types.ts
+++ b/apps/web/app/api/types.ts
@@ -15,6 +15,7 @@ export type EmbedLessonResource = {
 };
 
 export type AvailableCourseCategorySearchParams = {
+  userId?: string;
   title?: string;
   description?: string;
   searchQuery?: string;

--- a/apps/web/app/components/ErrorPage/ErrorPage.tsx
+++ b/apps/web/app/components/ErrorPage/ErrorPage.tsx
@@ -4,13 +4,17 @@ import { cn } from "../../lib/utils";
 import { Icon } from "../Icon";
 import { Button } from "../ui/button";
 
+import type { IconName } from "~/types/shared";
+
 type ErrorPageProps = {
   title: string;
   description?: string;
+  iconName?: IconName;
   actionLabel?: string;
   to?: string;
   onAction?: () => void;
   showAction?: boolean;
+  actionIcon?: IconName;
   className?: string;
   children?: React.ReactNode;
 };
@@ -18,40 +22,48 @@ type ErrorPageProps = {
 export default function ErrorPage({
   title,
   description,
+  iconName = "Blocked",
   actionLabel,
   to,
   onAction,
   showAction = true,
+  actionIcon,
   className,
   children,
 }: ErrorPageProps) {
   return (
     <div
       className={cn(
-        "relative flex min-h-screen w-full items-center justify-center bg-gradient-to-b from-primary-50/40 to-white dark:from-neutral-900 dark:to-neutral-950",
+        "relative flex min-h-screen w-full items-center justify-center bg-primary-50 px-4 py-10",
         className,
       )}
     >
-      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-        <div className="h-[28rem] w-[28rem] rounded-full bg-primary-100/30 blur-3xl dark:bg-primary-900/20" />
-      </div>
-
-      <div className="relative flex size-96 flex-col items-center justify-center rounded-full border border-neutral-200 bg-white/80 p-10 text-center shadow-xl backdrop-blur-md dark:border-neutral-800 bg-background">
-        <Icon name="Blocked" className="size-10 mb-6 text-primary-700" />
-        <h1 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100">{title}</h1>
+      <div className="relative w-full max-w-lg rounded-3xl border border-neutral-200/80 bg-background p-8 text-center dark:border-neutral-800 sm:p-12">
+        <div className="mx-auto mb-7 flex size-16 items-center justify-center rounded-2xl bg-primary-100 text-primary-700 shadow-inner dark:bg-primary-950 dark:text-primary-300">
+          <Icon name={iconName} className="size-8" aria-hidden="true" />
+        </div>
+        <h1 className="h4 text-neutral-950 dark:text-neutral-50">{title}</h1>
         {description && (
-          <p className="mt-3 px-4 text-sm text-neutral-600 dark:text-neutral-300">{description}</p>
+          <p className="mx-auto mt-2 max-w-sm body-base text-neutral-600 dark:text-neutral-300">
+            {description}
+          </p>
         )}
 
-        {children && <div className="mt-3 w-full px-4">{children}</div>}
+        {children && <div className="mt-8 w-full">{children}</div>}
 
         {showAction && (
-          <div className="mt-6">
+          <div className="mt-8">
             {onAction ? (
-              <Button onClick={onAction}>{actionLabel}</Button>
+              <Button onClick={onAction} className="gap-2">
+                {actionLabel}
+                {actionIcon && <Icon name={actionIcon} className="size-4" aria-hidden="true" />}
+              </Button>
             ) : (
               <Link to={to ?? "/"} prefetch="intent">
-                <Button>{actionLabel}</Button>
+                <Button className="gap-2">
+                  {actionLabel}
+                  {actionIcon && <Icon name={actionIcon} className="size-4" aria-hidden="true" />}
+                </Button>
               </Link>
             )}
           </div>

--- a/apps/web/app/hooks/useNavigationTracker.ts
+++ b/apps/web/app/hooks/useNavigationTracker.ts
@@ -22,7 +22,7 @@ export function useNavigationTracker() {
     if (currentUser || isAuthRoute || isRootRoute) return;
 
     addLastUnauthorizedEntry({
-      pathname: location.pathname,
+      pathname: `${location.pathname}${location.search}`,
       timestamp: Date.now(),
     });
   }, [
@@ -36,8 +36,16 @@ export function useNavigationTracker() {
 
   useEffect(() => {
     if (!currentUser || isAuthRoute || isRootRoute || !lastEntry) return;
-    if (lastEntry.pathname !== location.pathname) return;
+    if (lastEntry.pathname !== `${location.pathname}${location.search}`) return;
 
     clearHistory();
-  }, [clearHistory, currentUser, isAuthRoute, isRootRoute, lastEntry, location.pathname]);
+  }, [
+    clearHistory,
+    currentUser,
+    isAuthRoute,
+    isRootRoute,
+    lastEntry,
+    location.pathname,
+    location.search,
+  ]);
 }

--- a/apps/web/app/lib/stores/navigationHistory.test.ts
+++ b/apps/web/app/lib/stores/navigationHistory.test.ts
@@ -14,11 +14,11 @@ describe("navigation history", () => {
     saveEntryToNavigationHistory(new Request("https://app.example.com/admin/courses?tab=all"));
 
     expect(useNavigationHistoryStore.getState().navigationHistory).toEqual([
-      expect.objectContaining({ pathname: "/admin/courses" }),
+      expect.objectContaining({ pathname: "/admin/courses?tab=all" }),
     ]);
     expect(JSON.parse(sessionStorage.getItem("navigation-history") ?? "{}")).toMatchObject({
       state: {
-        navigationHistory: [expect.objectContaining({ pathname: "/admin/courses" })],
+        navigationHistory: [expect.objectContaining({ pathname: "/admin/courses?tab=all" })],
       },
     });
   });

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -3613,6 +3613,15 @@
     }
   },
   "studentCoursesView": {
+    "courseUnavailable": {
+      "accessTitle": "Kurz není dostupný",
+      "accessDescription": "Přihlaste se nebo si vytvořte účet a pokračujte ke kurzu.",
+      "goToLogin": "Přejít k přihlášení",
+      "goToCourseList": "Přejít na seznam kurzů",
+      "goToHome": "Přejít na domovskou stránku",
+      "notFoundTitle": "Kurz nebyl nalezen",
+      "notFoundDescription": "Tento kurz se nepodařilo najít."
+    },
     "other": {
       "cannotFindCourses": "Nenašli jsme žádné kurzy",
       "changeSearchCriteria": "Změňte prosím kritéria vyhledávání nebo to zkuste znovu později",

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -3607,6 +3607,15 @@
     }
   },
   "studentCoursesView": {
+    "courseUnavailable": {
+      "accessTitle": "Kurs ist nicht verfügbar",
+      "accessDescription": "Melden Sie sich an oder erstellen Sie ein Konto, um zum Kurs zu gelangen.",
+      "goToLogin": "Zum Login",
+      "goToCourseList": "Zur Kursliste",
+      "goToHome": "Zur Startseite",
+      "notFoundTitle": "Kurs nicht gefunden",
+      "notFoundDescription": "Dieser Kurs konnte nicht gefunden werden."
+    },
     "other": {
       "cannotFindCourses": "Wir konnten keine Kurse finden",
       "changeSearchCriteria": "Bitte ändern Sie die Suchkriterien oder versuchen Sie es später erneut",

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -3612,6 +3612,15 @@
     }
   },
   "studentCoursesView": {
+    "courseUnavailable": {
+      "accessTitle": "The course is unavailable",
+      "accessDescription": "Please sign in or create an account to continue to the course.",
+      "goToLogin": "Go to login",
+      "goToCourseList": "Go to course list",
+      "goToHome": "Go to home",
+      "notFoundTitle": "Course not found",
+      "notFoundDescription": "We could not find this course."
+    },
     "other": {
       "cannotFindCourses": "We could not find any courses",
       "changeSearchCriteria": "Please change the search criteria or try again later",

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -3551,6 +3551,15 @@
     }
   },
   "studentCoursesView": {
+    "courseUnavailable": {
+      "accessTitle": "El curso no está disponible",
+      "accessDescription": "Inicia sesión o crea una cuenta para continuar al curso.",
+      "goToLogin": "Ir al inicio de sesión",
+      "goToCourseList": "Ir a la lista de cursos",
+      "goToHome": "Ir al inicio",
+      "notFoundTitle": "Curso no encontrado",
+      "notFoundDescription": "No pudimos encontrar este curso."
+    },
     "other": {
       "cannotFindCourses": "No pudimos encontrar ningún curso.",
       "changeSearchCriteria": "Por favor cambie los criterios de búsqueda o vuelva a intentarlo más tarde.",

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -3608,6 +3608,15 @@
     }
   },
   "studentCoursesView": {
+    "courseUnavailable": {
+      "accessTitle": "Kursas nepasiekiamas",
+      "accessDescription": "Prisijunkite arba sukurkite paskyrą, kad galėtumėte tęsti kursą.",
+      "goToLogin": "Eiti į prisijungimą",
+      "goToCourseList": "Eiti į kursų sąrašą",
+      "goToHome": "Eiti į pagrindinį puslapį",
+      "notFoundTitle": "Kursas nerastas",
+      "notFoundDescription": "Šio kurso rasti nepavyko."
+    },
     "other": {
       "cannotFindCourses": "Neradome jokių kursų",
       "changeSearchCriteria": "Pakeiskite paieškos kriterijus arba bandykite dar kartą vėliau",

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -3843,6 +3843,15 @@
     }
   },
   "studentCoursesView": {
+    "courseUnavailable": {
+      "accessTitle": "Kurs jest niedostępny",
+      "accessDescription": "Zaloguj się lub utwórz konto, aby przejść do kursu.",
+      "goToLogin": "Przejdź do logowania",
+      "goToCourseList": "Przejdź do listy kursów",
+      "goToHome": "Przejdź do strony głównej",
+      "notFoundTitle": "Nie znaleziono kursu",
+      "notFoundDescription": "Nie udało się znaleźć tego kursu."
+    },
     "other": {
       "cannotFindCourses": "Nie znaleziono żadnych kursów",
       "changeSearchCriteria": "Zmień kryteria wyszukiwania lub spróbuj ponownie później",

--- a/apps/web/app/modules/Courses/CourseView/CourseUnavailable.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseUnavailable.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+
+import ErrorPage from "~/components/ErrorPage/ErrorPage";
+import { LOGIN_REDIRECT_URL } from "~/modules/Auth/constants";
+
+import { COURSE_UNAVAILABLE_REASONS, type CourseUnavailableReason } from "./CourseView.constants";
+
+type CourseUnavailableProps = {
+  reason: CourseUnavailableReason;
+  canAccessCourseList: boolean;
+};
+
+export default function CourseUnavailable({ reason, canAccessCourseList }: CourseUnavailableProps) {
+  const { t } = useTranslation();
+
+  if (reason === COURSE_UNAVAILABLE_REASONS.NOT_FOUND) {
+    return (
+      <ErrorPage
+        iconName="Search"
+        title={t("studentCoursesView.courseUnavailable.notFoundTitle")}
+        description={t("studentCoursesView.courseUnavailable.notFoundDescription")}
+        actionLabel={t(
+          canAccessCourseList
+            ? "studentCoursesView.courseUnavailable.goToCourseList"
+            : "studentCoursesView.courseUnavailable.goToHome",
+        )}
+        actionIcon="ArrowRight"
+        to={canAccessCourseList ? "/courses" : LOGIN_REDIRECT_URL}
+      />
+    );
+  }
+
+  return (
+    <ErrorPage
+      title={t("studentCoursesView.courseUnavailable.accessTitle")}
+      description={t("studentCoursesView.courseUnavailable.accessDescription")}
+      actionLabel={t("studentCoursesView.courseUnavailable.goToLogin")}
+      actionIcon="ArrowRight"
+      to="/auth/login"
+    />
+  );
+}

--- a/apps/web/app/modules/Courses/CourseView/CourseView.constants.ts
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.constants.ts
@@ -1,0 +1,12 @@
+export const COURSE_VIEW_LOADER_STATUS = {
+  AVAILABLE: "available",
+  UNAVAILABLE: "unavailable",
+} as const;
+
+export const COURSE_UNAVAILABLE_REASONS = {
+  REQUIRES_AUTHENTICATION: "requiresAuthentication",
+  NOT_FOUND: "notFound",
+} as const;
+
+export type CourseUnavailableReason =
+  (typeof COURSE_UNAVAILABLE_REASONS)[keyof typeof COURSE_UNAVAILABLE_REASONS];

--- a/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseView.page.tsx
@@ -1,25 +1,55 @@
-import { redirect, useNavigate, useParams, useSearchParams } from "@remix-run/react";
-import { ACCESS_GUARD, SUPPORTED_LANGUAGES } from "@repo/shared";
+import { redirect, useLoaderData, useNavigate, useParams, useSearchParams } from "@remix-run/react";
+import { ACCESS_GUARD, PERMISSIONS, SUPPORTED_LANGUAGES } from "@repo/shared";
 import { isAxiosError } from "axios";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { courseLookupQueryOptions, courseQueryOptions, useCourse } from "~/api/queries";
+import {
+  courseLookupQueryOptions,
+  courseQueryOptions,
+  currentUserQueryOptions,
+  useCourse,
+} from "~/api/queries";
+import { globalSettingsQueryOptions } from "~/api/queries/useGlobalSettings";
 import { userSettingsQueryOptions } from "~/api/queries/useUserSettings";
 import { queryClient } from "~/api/queryClient";
+import { hasPermission } from "~/common/permissions/permission.utils";
 import { PageWrapper } from "~/components/PageWrapper";
 import { ContentAccessGuard } from "~/Guards/AccessGuard";
 import { CourseAccessProvider } from "~/modules/Courses/context/CourseAccessProvider";
 import CourseOverview from "~/modules/Courses/CourseView/CourseOverview/CourseOverview";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
 import { isSupportedLanguage } from "~/utils/browser-language";
+import { saveEntryToNavigationHistory } from "~/utils/saveEntryToNavigationHistory";
 
 import { buildCourseRedirectPath } from "./courseRedirect.utils";
 import { CourseStatBar } from "./CourseStatBar/CourseStatBar";
+import CourseUnavailable from "./CourseUnavailable";
+import {
+  COURSE_UNAVAILABLE_REASONS,
+  COURSE_VIEW_LOADER_STATUS,
+  type CourseUnavailableReason,
+} from "./CourseView.constants";
 import { LearningModeBanner } from "./LearningModeBanner";
 import { TableOfContent } from "./TableOfContent/TableOfContent";
 
 import type { SupportedLanguages } from "@repo/shared";
+
+type CourseViewLoaderData =
+  | { status: (typeof COURSE_VIEW_LOADER_STATUS)["AVAILABLE"] }
+  | {
+      status: (typeof COURSE_VIEW_LOADER_STATUS)["UNAVAILABLE"];
+      reason: CourseUnavailableReason;
+      canAccessCourseList: boolean;
+    }
+  | null;
+
+const getNotFoundLoaderData = (canAccessCourseList: boolean) =>
+  ({
+    status: COURSE_VIEW_LOADER_STATUS.UNAVAILABLE,
+    reason: COURSE_UNAVAILABLE_REASONS.NOT_FOUND,
+    canAccessCourseList,
+  }) as const;
 
 const resolvePreferredLanguage = (
   url: URL,
@@ -55,7 +85,25 @@ export const clientLoader = async ({
   if (!idOrSlug) return null;
 
   const url = new URL(request.url);
-  const userSettingsResponse = await queryClient.ensureQueryData(userSettingsQueryOptions);
+
+  const [currentUserResponse, globalSettingsResponse, userSettingsResponse] = await Promise.all([
+    queryClient.ensureQueryData(currentUserQueryOptions),
+    queryClient.ensureQueryData(globalSettingsQueryOptions),
+    queryClient.ensureQueryData(userSettingsQueryOptions),
+  ]);
+
+  const currentUser = currentUserResponse?.data;
+
+  if (!currentUser && !globalSettingsResponse?.data?.unregisteredUserCoursesAccessibility) {
+    saveEntryToNavigationHistory(request);
+
+    return {
+      status: COURSE_VIEW_LOADER_STATUS.UNAVAILABLE,
+      reason: COURSE_UNAVAILABLE_REASONS.REQUIRES_AUTHENTICATION,
+      canAccessCourseList: false,
+    } as const;
+  }
+
   const language = resolvePreferredLanguage(url, userSettingsResponse?.data?.language);
   useLanguageStore.getState().setLanguage(language);
 
@@ -63,11 +111,15 @@ export const clientLoader = async ({
     .fetchQuery(courseLookupQueryOptions(idOrSlug, language))
     .catch((error: unknown) => {
       if (isAxiosError(error) && error.response?.status === 404) {
-        throw redirect("/courses", 302);
+        return getNotFoundLoaderData(
+          !currentUser || hasPermission(currentUser.permissions, PERMISSIONS.COURSE_READ),
+        );
       }
 
       throw error;
     });
+
+  if (lookupCourse.status === COURSE_VIEW_LOADER_STATUS.UNAVAILABLE) return lookupCourse;
 
   const { status, slug } = lookupCourse;
 
@@ -75,20 +127,26 @@ export const clientLoader = async ({
     throw redirect(buildCourseRedirectPath(request.url, slug), 302);
   }
 
-  await queryClient
+  const courseResponse = await queryClient
     .ensureQueryData(courseQueryOptions(idOrSlug, language))
     .catch((error: unknown) => {
       if (isAxiosError(error) && error.response?.status === 404) {
-        throw redirect("/courses", 302);
+        return null;
       }
-
       throw error;
     });
 
-  return null;
+  if (!courseResponse)
+    return getNotFoundLoaderData(
+      !currentUser || hasPermission(currentUser.permissions, PERMISSIONS.COURSE_READ),
+    );
+
+  return { status: COURSE_VIEW_LOADER_STATUS.AVAILABLE } as const;
 };
 
 export default function CourseViewPage() {
+  const loaderData = useLoaderData() as CourseViewLoaderData;
+
   const { t } = useTranslation();
   const { id = "" } = useParams();
   const navigate = useNavigate();
@@ -100,7 +158,11 @@ export default function CourseViewPage() {
   const language =
     previewLanguage && isSupportedLanguage(previewLanguage) ? previewLanguage : defaultLanguage;
 
-  const { data: course, error } = useCourse(id, language);
+  const { data: course, error } = useCourse(
+    id,
+    language,
+    loaderData?.status === COURSE_VIEW_LOADER_STATUS.AVAILABLE,
+  );
 
   const handleCourseLanguageChange = useCallback(
     (nextLanguage: SupportedLanguages) => {
@@ -137,6 +199,15 @@ export default function CourseViewPage() {
       handleCourseLanguageChange(course.baseLanguage);
     }
   }, [course, handleCourseLanguageChange, language]);
+
+  if (loaderData?.status === COURSE_VIEW_LOADER_STATUS.UNAVAILABLE) {
+    return (
+      <CourseUnavailable
+        reason={loaderData.reason}
+        canAccessCourseList={loaderData.canAccessCourseList}
+      />
+    );
+  }
 
   if (!course) return null;
   const breadcrumbs = [

--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -103,6 +103,7 @@ export default function LessonPage() {
         title={t("studentLessonView.error.notAuthorizedTitle")}
         description={t("studentLessonView.error.notAuthorizedDescription")}
         actionLabel={t("studentLessonView.error.goBackToCourse")}
+        actionIcon="ArrowRight"
         to={`/course/${courseId}`}
       />
     );

--- a/apps/web/app/modules/Courses/components/modern/ModernCoursesView.tsx
+++ b/apps/web/app/modules/Courses/components/modern/ModernCoursesView.tsx
@@ -33,6 +33,7 @@ const CATEGORY_PAGE_SIZE = 4;
 type CategoryCoursesRowProps = {
   category: GetAllCategoriesResponse["data"][number];
   progressByCourseId: Record<string, number | undefined>;
+  userId?: string;
   rowRef?: Ref<HTMLElement>;
 };
 
@@ -46,7 +47,12 @@ type HeroCourse = {
   slug: string;
 };
 
-const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCoursesRowProps) => {
+const CategoryCoursesRow = ({
+  category,
+  progressByCourseId,
+  userId,
+  rowRef,
+}: CategoryCoursesRowProps) => {
   const { language } = useLanguageStore();
   const prefetchedAfterPageRef = useRef(0);
   const hasNextPageRef = useRef(false);
@@ -57,6 +63,7 @@ const CategoryCoursesRow = ({ category, progressByCourseId, rowRef }: CategoryCo
       {
         category: category.title,
         language,
+        userId,
       },
       COURSE_PAGE_SIZE,
       { notifyOnChangeProps: ["data", "isLoading", "hasNextPage", "isFetchingNextPage"] },
@@ -184,7 +191,10 @@ const ModernCoursesView = () => {
     hasNextPage: hasNextCategoriesPage,
     isFetchingNextPage: isFetchingNextCategoriesPage,
     fetchNextPage: fetchNextCategoriesPage,
-  } = useInfiniteAvailableCourseCategories({ language }, CATEGORY_PAGE_SIZE);
+  } = useInfiniteAvailableCourseCategories(
+    { language, userId: currentUser?.id },
+    CATEGORY_PAGE_SIZE,
+  );
 
   const categories = useMemo(
     () =>
@@ -381,6 +391,7 @@ const ModernCoursesView = () => {
                   key={category.id}
                   category={category}
                   progressByCourseId={progressByCourseId}
+                  userId={currentUser?.id}
                   rowRef={index === categories.length - 1 ? lastCategoryRowRef : undefined}
                 />
               )),

--- a/apps/web/app/utils/saveEntryToNavigationHistory.ts
+++ b/apps/web/app/utils/saveEntryToNavigationHistory.ts
@@ -4,7 +4,7 @@ export const saveEntryToNavigationHistory = (request: Request) => {
   const attemptedUrl = new URL(request.url);
 
   useNavigationHistoryStore.getState().addLastUnauthorizedEntry({
-    pathname: attemptedUrl.pathname,
+    pathname: `${attemptedUrl.pathname}${attemptedUrl.search}`,
     timestamp: Date.now(),
   });
 };


### PR DESCRIPTION
## Issue(s)
- #1905

## Overview

This change makes course lookup unavailable to unauthenticated users when the tenant does not allow unregistered course access.

It adds reason-specific course unavailable handling, preserves the original course URL through authentication, and keeps unavailable course responses indistinguishable from regular 404 responses. It also improves the unavailable error page and fixes category filtering when a category falls back to its base language.

## Business Value

Users receive a clear explanation and an actionable next step instead of being redirected through a confusing or broken navigation flow. After logging in, they can return to the course they originally requested.

The change also prevents unauthorized course discovery while preserving the configured public-course experience for tenants that allow it.

## Screenshots / Video

https://github.com/user-attachments/assets/df3542ae-9697-4591-b270-87597d5f095c
