### PR TITLE
fix: display breadcrumb navigation in the correct language

### DIFF
--- a/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
+++ b/apps/web/app/modules/Courses/Lesson/Lesson.page.tsx
@@ -44,7 +44,7 @@ export default function LessonPage() {
   const { t } = useTranslation();
   const { courseId = "", lessonId = "" } = useParams();
 
-  const { language } = useLanguageStore();
+  const { language, setLanguage } = useLanguageStore();
   const { data: user } = useCurrentUser();
 
   const [error, setError] = useState(false);
@@ -58,6 +58,10 @@ export default function LessonPage() {
     isError: lessonError,
   } = useLesson(lessonId, language, user?.id || "");
   const { data: course } = useCourse(courseId, language);
+
+  useEffect(() => {
+    if (course && !course.availableLocales.includes(language)) setLanguage(course.baseLanguage);
+  }, [course, language, setLanguage]);
 
   useEffect(() => {
     let isCurrentRequest = true;


### PR DESCRIPTION
## Issue(s)
- #1869 

## Overview

Fixes missing course and chapter breadcrumb translations in the lesson view when the selected application language is not available for the course.

The lesson page now switches to the course base language before rendering the course context, keeping the breadcrumb labels and lesson content aligned with an available translation.

## Business Value

Learners, administrators, and content creators can reliably identify their current course and chapter while navigating lessons. This prevents blank breadcrumb labels and provides a clearer, more consistent learning experience across multilingual courses.