### PR TITLE
chore: prevent editing course details for shared courses

### DIFF
--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -12,6 +12,7 @@ import {
   buildCertificateMarkup,
   CERTIFICATE_ARCHIVE_REASONS,
   CERTIFICATE_RESET_SCOPES,
+  DEFAULT_CERTIFICATE_FONT_COLOR,
   CERTIFICATE_VALIDITY_TYPES,
   CERTIFICATE_VALIDITY_UNITS,
   PERMISSIONS,
@@ -527,7 +528,7 @@ export class CertificatesService implements OnModuleDestroy {
         this.getImageDataUriFromS3Key(imageSettings.certificateBackgroundImage),
       ]);
 
-    const accentColor = certificate.certificateFontColor || imageSettings.primaryColor || "#1f2937";
+    const accentColor = certificate.certificateFontColor || DEFAULT_CERTIFICATE_FONT_COLOR;
     const certificateDate =
       certificate.issuedAt || certificate.completionDate || certificate.createdAt;
 
@@ -857,8 +858,7 @@ export class CertificatesService implements OnModuleDestroy {
   }
 
   private buildShareImageMarkup(context: ShareRenderContext): string {
-    const accentColor =
-      context.certificate.certificateFontColor || context.settings.primaryColor || "#1f2937";
+    const accentColor = context.certificate.certificateFontColor || DEFAULT_CERTIFICATE_FONT_COLOR;
 
     return buildCertificateMarkup({
       studentName: context.certificate.fullName || "",

--- a/apps/api/src/courses/course.service.ts
+++ b/apps/api/src/courses/course.service.ts
@@ -16,6 +16,7 @@ import {
   COURSE_ORIGIN_TYPES,
   COURSE_STATUSES,
   COURSE_TYPE,
+  DEFAULT_CERTIFICATE_FONT_COLOR,
   ENTITY_TYPES,
   PERMISSIONS,
   type PermissionKey,
@@ -2095,7 +2096,24 @@ export class CourseService {
     currentUser: CurrentUserType,
     certificateSignature?: Express.Multer.File | null,
   ) {
-    await this.masterCourseService.assertCourseContentEditable(courseId);
+    const certificateSettingKeys = [
+      "certificateValidity",
+      "applyValidityToExistingCertificates",
+      "certificateFontColor",
+      "removeCertificateSignature",
+      "certificateSignature",
+    ];
+    const attemptedSettingKeys = Object.entries(settings)
+      .filter(([, value]) => value !== undefined)
+      .map(([key]) => key);
+
+    if (certificateSignature) attemptedSettingKeys.push("certificateSignature");
+
+    await this.masterCourseService.assertCourseContentEditable(
+      courseId,
+      certificateSettingKeys,
+      attemptedSettingKeys,
+    );
 
     const [course] = await this.db.select().from(courses).where(eq(courses.id, courseId));
 
@@ -2292,7 +2310,7 @@ export class CourseService {
         isScormCourse ? false : VIDEO_COMPLETION_TRACKING_ENABLED
       }::boolean,
       'certificateSignature', NULL,
-      'certificateFontColor', NULL,
+      'certificateFontColor', ${DEFAULT_CERTIFICATE_FONT_COLOR},
       'certificateValidity', NULL
     )`;
 

--- a/apps/api/src/courses/master-course.service.ts
+++ b/apps/api/src/courses/master-course.service.ts
@@ -12,6 +12,7 @@ import {
 import {
   AI_MENTOR_TYPE,
   COURSE_ORIGIN_TYPES,
+  DEFAULT_CERTIFICATE_FONT_COLOR,
   ENTITY_TYPES,
   LESSON_TYPES,
   MASTER_COURSE_ENTITY_TYPES,
@@ -262,7 +263,7 @@ export class MasterCourseService {
       quizFeedbackEnabled: QUIZ_FEEDBACK_ENABLED,
       videoCompletionTrackingEnabled: VIDEO_COMPLETION_TRACKING_ENABLED,
       certificateSignature: null,
-      certificateFontColor: null,
+      certificateFontColor: DEFAULT_CERTIFICATE_FONT_COLOR,
       certificateValidity: null,
     });
 
@@ -568,7 +569,7 @@ export class MasterCourseService {
         quizFeedbackEnabled: QUIZ_FEEDBACK_ENABLED,
         videoCompletionTrackingEnabled: VIDEO_COMPLETION_TRACKING_ENABLED,
         certificateSignature: null,
-        certificateFontColor: null,
+        certificateFontColor: DEFAULT_CERTIFICATE_FONT_COLOR,
         certificateValidity: null,
       });
 
@@ -1847,7 +1848,7 @@ export class MasterCourseService {
       quizFeedbackEnabled: QUIZ_FEEDBACK_ENABLED,
       videoCompletionTrackingEnabled: VIDEO_COMPLETION_TRACKING_ENABLED,
       certificateSignature: null,
-      certificateFontColor: null,
+      certificateFontColor: DEFAULT_CERTIFICATE_FONT_COLOR,
       certificateValidity: null,
     });
 

--- a/apps/api/src/courses/types/settings.ts
+++ b/apps/api/src/courses/types/settings.ts
@@ -1,4 +1,8 @@
-import { CERTIFICATE_VALIDITY_TYPES, CERTIFICATE_VALIDITY_UNITS } from "@repo/shared";
+import {
+  CERTIFICATE_VALIDITY_TYPES,
+  CERTIFICATE_VALIDITY_UNITS,
+  DEFAULT_CERTIFICATE_FONT_COLOR,
+} from "@repo/shared";
 import { Type, type Static } from "@sinclair/typebox";
 
 import {
@@ -42,7 +46,7 @@ export const coursesSettingsSchema = Type.Object(
       default: null,
     }),
     certificateFontColor: Type.Union([Type.String(), Type.Null()], {
-      default: null,
+      default: DEFAULT_CERTIFICATE_FONT_COLOR,
     }),
     certificateValidity: Type.Union([certificateValiditySchema, Type.Null()], {
       default: null,

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -32389,7 +32389,7 @@
                 ]
               },
               "certificateFontColor": {
-                "default": null,
+                "default": "#000000",
                 "anyOf": [
                   {
                     "type": "string"

--- a/apps/api/src/user/__tests__/user.controller.e2e-spec.ts
+++ b/apps/api/src/user/__tests__/user.controller.e2e-spec.ts
@@ -216,6 +216,7 @@ describe("UsersController (e2e)", () => {
 
       const courseResponse = await request(app.getHttpServer())
         .get(`/api/course?id=${course.id}&language=en`)
+        .set("Cookie", testCookies)
         .expect(200);
 
       expect(courseResponse.body.data.author).toMatchObject({

--- a/apps/api/test/factory/course.factory.ts
+++ b/apps/api/test/factory/course.factory.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { COURSE_TYPE, SUPPORTED_LANGUAGES } from "@repo/shared";
+import { COURSE_TYPE, DEFAULT_CERTIFICATE_FONT_COLOR, SUPPORTED_LANGUAGES } from "@repo/shared";
 import { getTableColumns, sql } from "drizzle-orm";
 import { Factory } from "fishery";
 
@@ -121,7 +121,7 @@ export const createCourseFactory = (db: DatabasePg) => {
         lessonSequenceEnabled: LESSON_SEQUENCE_ENABLED,
         quizFeedbackEnabled: QUIZ_FEEDBACK_ENABLED,
         certificateSignature: null,
-        certificateFontColor: null,
+        certificateFontColor: DEFAULT_CERTIFICATE_FONT_COLOR,
         certificateValidity: null,
       },
     };

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -2779,7 +2779,7 @@ export interface GetCourseSettingsResponse {
     videoCompletionTrackingEnabled?: boolean;
     /** @default null */
     certificateSignature: string | null;
-    /** @default null */
+    /** @default "#000000" */
     certificateFontColor: string | null;
     /** @default null */
     certificateValidity:

--- a/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/EditCourse.tsx
@@ -468,6 +468,7 @@ const EditCourse = () => {
                         }
                       }
                       isAIConfigured={isAIConfigured?.enabled ?? false}
+                      canAddLanguage={!isExportedCourse}
                       onChange={setCourseLanguage}
                       setOpenGenerateTranslationModal={setOpenGenerateTranslationModal}
                     />

--- a/apps/web/app/modules/Admin/EditCourse/components/CourseLanguageSelector.test.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/components/CourseLanguageSelector.test.tsx
@@ -101,4 +101,29 @@ describe("CourseLanguageSelector", () => {
 
     expect(setOpenGenerateTranslationModal).toHaveBeenCalledWith(true);
   });
+
+  it("hides languages that can be added when adding languages is disabled", async () => {
+    const user = userEvent.setup();
+
+    renderWith().render(
+      <CourseLanguageSelector
+        courseLanguage="en"
+        course={{
+          id: "course-1",
+          baseLanguage: "en",
+          availableLocales: ["en"],
+        }}
+        canAddLanguage={false}
+        isAIConfigured={false}
+        onChange={vi.fn()}
+        setOpenGenerateTranslationModal={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTestId(EDIT_COURSE_PAGE_HANDLES.LANGUAGE_SELECT));
+
+    expect(
+      screen.queryByTestId(EDIT_COURSE_PAGE_HANDLES.languageOption("de")),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/app/modules/Admin/EditCourse/components/CourseLanguageSelector.tsx
+++ b/apps/web/app/modules/Admin/EditCourse/components/CourseLanguageSelector.tsx
@@ -41,6 +41,7 @@ type LanguageSelectorProps = {
   onChange: (language: SupportedLanguages) => void;
   setOpenGenerateTranslationModal: (open: boolean) => void;
   isAIConfigured: boolean;
+  canAddLanguage?: boolean;
   hasMissingTranslations?: boolean;
   className?: string;
   compactOnMobile?: boolean;
@@ -54,6 +55,7 @@ export const CourseLanguageSelector = ({
   onChange,
   setOpenGenerateTranslationModal,
   isAIConfigured,
+  canAddLanguage = true,
   hasMissingTranslations = false,
   className,
   compactOnMobile,
@@ -72,9 +74,9 @@ export const CourseLanguageSelector = ({
   const addedItems = courseLanguages.filter(
     (item) => !!course?.availableLocales?.includes(item.key),
   );
-  const notAddedItems = courseLanguages.filter(
-    (item) => !(course?.availableLocales?.includes(item.key) ?? false),
-  );
+  const notAddedItems = canAddLanguage
+    ? courseLanguages.filter((item) => !(course?.availableLocales?.includes(item.key) ?? false))
+    : [];
 
   const baseLanguageTranslationKey = courseLanguages.find(
     (item) => item.key === course?.baseLanguage,

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseCategoryEditor.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseCategoryEditor.test.tsx
@@ -64,6 +64,12 @@ describe("CourseCategoryEditor", () => {
     expect(screen.queryByRole("link", { name: "Manage categories" })).not.toBeInTheDocument();
   });
 
+  it("exposes the category control as disabled when editing is not allowed", () => {
+    renderEditor({ ...defaultProps, canEdit: false, isEditing: false });
+
+    expect(screen.getByTestId(COURSE_SETTINGS_HANDLES.CATEGORY_SELECT)).toBeDisabled();
+  });
+
   it("styles the missing-category placeholder like the missing course title", () => {
     renderEditor({
       ...defaultProps,

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseCategoryEditor.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseCategoryEditor.tsx
@@ -112,6 +112,7 @@ export default function CourseCategoryEditor({
       ) : (
         <button
           type="button"
+          data-testid={COURSE_SETTINGS_HANDLES.CATEGORY_SELECT}
           disabled={!canEdit}
           onClick={() => {
             if (canEdit) {

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseDescriptionModal.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseDescriptionModal.test.tsx
@@ -27,6 +27,7 @@ describe("CourseDescriptionModal", () => {
 
     renderWith().render(
       <CourseDescriptionModal
+        canEdit
         courseDescription="Course description"
         onChangeDescription={vi.fn()}
         onClose={onClose}

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseDescriptionModal.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseDescriptionModal.tsx
@@ -11,6 +11,7 @@ import { COURSE_SETTINGS_HANDLES } from "../../../../../e2e/data/courses/handles
 import { useCourseAccessProvider } from "../../context/CourseAccessProvider";
 
 type CourseDescriptionModalProps = {
+  canEdit: boolean;
   courseDescription: string;
   onChangeDescription: (description: string) => void;
   onClose: () => void;
@@ -18,17 +19,17 @@ type CourseDescriptionModalProps = {
 };
 
 export default function CourseDescriptionModal({
+  canEdit,
   courseDescription,
   onChangeDescription,
   onClose,
   onSaveDescription,
 }: CourseDescriptionModalProps) {
-  const { course, isAdminExperience } = useCourseAccessProvider();
+  const { course } = useCourseAccessProvider();
   const { t } = useTranslation();
+
   const saveAndClose = async () => {
-    if (isAdminExperience) {
-      await onSaveDescription();
-    }
+    if (canEdit) await onSaveDescription();
     onClose();
   };
 
@@ -79,7 +80,7 @@ export default function CourseDescriptionModal({
             <h5 className="mb-3 font-bold text-neutral-950">
               {t("modernCourseView.overview.description")}
             </h5>
-            {isAdminExperience ? (
+            {canEdit ? (
               <div data-testid={COURSE_SETTINGS_HANDLES.DESCRIPTION_EDITOR}>
                 <BaseEditor
                   content={courseDescription}
@@ -123,11 +124,7 @@ export default function CourseDescriptionModal({
               onClick={() => void saveAndClose()}
               className="px-6 font-semibold"
             >
-              {t(
-                isAdminExperience
-                  ? "modernCourseView.common.saveChanges"
-                  : "modernCourseView.common.close",
-              )}
+              {t(canEdit ? "modernCourseView.common.saveChanges" : "modernCourseView.common.close")}
             </Button>
           </div>
         </div>

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverview.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverview.test.tsx
@@ -1,3 +1,4 @@
+import { COURSE_ORIGIN_TYPES, type CourseOriginType } from "@repo/shared";
 import { screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
@@ -30,6 +31,7 @@ const course = {
   description: "Course description",
   estimatedDurationSeconds: 3_600,
   learningOutcomes: [],
+  originType: COURSE_ORIGIN_TYPES.REGULAR as CourseOriginType,
   thumbnailPositionY: 50,
   thumbnailUrl: "/course-image.jpg",
   title: "Course title",
@@ -120,11 +122,18 @@ vi.mock("~/modules/Admin/EditCourse/components/CourseLanguageSelector", () => ({
 }));
 
 vi.mock("./CourseCategoryEditor", () => ({
-  default: ({ onChange }: { onChange: (categoryId: string) => Promise<void> }) => (
-    <button type="button" onClick={() => void onChange("category-2")}>
-      Change category
-    </button>
-  ),
+  default: ({
+    canEdit,
+    onChange,
+  }: {
+    canEdit: boolean;
+    onChange: (categoryId: string) => Promise<void>;
+  }) =>
+    canEdit && (
+      <button type="button" onClick={() => void onChange("category-2")}>
+        Change category
+      </button>
+    ),
 }));
 
 vi.mock("./CourseDescriptionModal", () => ({
@@ -213,21 +222,24 @@ vi.mock("./CourseSettingsDrawer", () => ({
 
 vi.mock("./CourseTitleEditor", () => ({
   default: ({
+    canEdit,
     onChange,
     onSave,
   }: {
+    canEdit: boolean;
     onChange: (title: string) => void;
     onSave: () => Promise<void>;
-  }) => (
-    <div>
-      <button type="button" onClick={() => onChange("Updated course title")}>
-        Change title
-      </button>
-      <button type="button" onClick={() => void onSave()}>
-        Save title
-      </button>
-    </div>
-  ),
+  }) =>
+    canEdit && (
+      <div>
+        <button type="button" onClick={() => onChange("Updated course title")}>
+          Change title
+        </button>
+        <button type="button" onClick={() => void onSave()}>
+          Save title
+        </button>
+      </div>
+    ),
 }));
 
 vi.mock("./CourseWhatYouWillLearn", () => ({
@@ -388,5 +400,25 @@ describe("CourseOverview", () => {
         courseOverviewCache: { idOrSlug: "course-slug", language: "en" },
       });
     });
+  });
+
+  it("hides metadata and media editing for shared courses", () => {
+    course.originType = COURSE_ORIGIN_TYPES.EXPORTED;
+
+    renderWith().render(
+      <MemoryRouter>
+        <CourseOverview
+          idOrSlug="course-slug"
+          language="en"
+          onLanguageChange={vi.fn()}
+          openGenerateTranslationModal={false}
+          setOpenGenerateTranslationModal={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId(COURSE_OVERVIEW_HANDLES.EDIT_MEDIA_BUTTON)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Change title" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Change category" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverview.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseOverview.tsx
@@ -1,6 +1,11 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@remix-run/react";
-import { ENTITY_TYPES, MAX_COURSE_TRAILER_VIDEO_SIZE, PERMISSIONS } from "@repo/shared";
+import {
+  COURSE_ORIGIN_TYPES,
+  ENTITY_TYPES,
+  MAX_COURSE_TRAILER_VIDEO_SIZE,
+  PERMISSIONS,
+} from "@repo/shared";
 import { Settings, Upload } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -70,6 +75,9 @@ export default function CourseOverview({
   const navigate = useNavigate();
   const { course, isAdminExperience, isCourseStudentModeActive, isPreviewMode } =
     useCourseAccessProvider();
+
+  const isSharedCourse = course.originType === COURSE_ORIGIN_TYPES.EXPORTED;
+  const canEditCourseMetadata = isAdminExperience && !isSharedCourse;
 
   const { data: currentUser } = useCurrentUser();
   const { data: categories = [] } = useCategories({
@@ -356,18 +364,20 @@ export default function CourseOverview({
                 </span>
               </Button>
 
-              <Button
-                variant="outline"
-                onClick={openMediaModal}
-                data-testid={COURSE_OVERVIEW_HANDLES.EDIT_MEDIA_BUTTON}
-                className="flex size-10 shrink-0 items-center gap-2 p-0 shadow-sm backdrop-blur-sm transition sm:w-auto sm:px-4"
-              >
-                <Upload className="size-4 text-primary-700" />
+              {canEditCourseMetadata && (
+                <Button
+                  variant="outline"
+                  onClick={openMediaModal}
+                  data-testid={COURSE_OVERVIEW_HANDLES.EDIT_MEDIA_BUTTON}
+                  className="flex size-10 shrink-0 items-center gap-2 p-0 shadow-sm backdrop-blur-sm transition sm:w-auto sm:px-4"
+                >
+                  <Upload className="size-4 text-primary-700" />
 
-                <span className="hidden text-sm font-semibold text-neutral-950 sm:inline">
-                  {t("modernCourseView.overview.editMedia")}
-                </span>
-              </Button>
+                  <span className="hidden text-sm font-semibold text-neutral-950 sm:inline">
+                    {t("modernCourseView.overview.editMedia")}
+                  </span>
+                </Button>
+              )}
             </div>
 
             <CourseLanguageSelector
@@ -378,6 +388,7 @@ export default function CourseOverview({
                 availableLocales: course.availableLocales,
               }}
               isAIConfigured={isAIConfigured?.enabled ?? false}
+              canAddLanguage={!isSharedCourse}
               hasMissingTranslations={hasMissingTranslations}
               onChange={onLanguageChange}
               setOpenGenerateTranslationModal={setOpenGenerateTranslationModal}
@@ -403,7 +414,7 @@ export default function CourseOverview({
               categoryId={categoryId}
               categoryTitle={selectedCategoryTitle}
               categories={categories}
-              canEdit={isAdminExperience}
+              canEdit={canEditCourseMetadata}
               canManageCategories={canManageCategories}
               disabled={isUpdatingCourse}
               durationSeconds={course.estimatedDurationSeconds}
@@ -418,7 +429,7 @@ export default function CourseOverview({
 
             <CourseTitleEditor
               title={title}
-              canEdit={isAdminExperience}
+              canEdit={canEditCourseMetadata}
               disabled={isUpdatingCourse}
               isEditing={isEditingTitle}
               onCancel={handleCancelTitleEdit}
@@ -503,6 +514,7 @@ export default function CourseOverview({
 
       {showDescriptionModal && (
         <CourseDescriptionModal
+          canEdit={canEditCourseMetadata}
           courseDescription={description}
           onChangeDescription={(nextDescription) =>
             setValue("description", nextDescription, {
@@ -519,6 +531,7 @@ export default function CourseOverview({
         currency={course.currency}
         courseId={course.id}
         language={language}
+        isSharedCourse={isSharedCourse}
         onOpenChange={setShowSettingsDrawer}
         open={showSettingsDrawer}
         priceInCents={course.priceInCents}

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseSettingsDrawer.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseSettingsDrawer.test.tsx
@@ -19,10 +19,11 @@ describe("CourseSettingsDrawer", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
 
-    renderWith().render(
+    renderWith({ withQuery: true }).render(
       <CourseSettingsDrawer
         courseId="course-id"
         language="en"
+        isSharedCourse={false}
         onOpenChange={onOpenChange}
         open
         status="draft"
@@ -37,5 +38,23 @@ describe("CourseSettingsDrawer", () => {
     await user.keyboard("{Escape}");
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("only exposes local rollout controls for shared courses", () => {
+    renderWith({ withQuery: true }).render(
+      <CourseSettingsDrawer
+        courseId="course-id"
+        isSharedCourse
+        language="en"
+        onOpenChange={vi.fn()}
+        open
+        status="draft"
+        title="Course settings"
+        unsupportedLessonCount={0}
+      />,
+    );
+
+    expect(screen.getByTestId("course-overview-settings-tab-status")).toBeInTheDocument();
+    expect(screen.queryByText("Course settings switches")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseSettingsDrawer.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseSettingsDrawer.tsx
@@ -42,6 +42,7 @@ type CourseSettingsDrawerProps = {
   open: boolean;
   priceInCents?: number;
   status: CourseStatusValue;
+  isSharedCourse: boolean;
   title: string;
   unsupportedLessonCount: number;
 };
@@ -54,18 +55,21 @@ export default function CourseSettingsDrawer({
   open,
   priceInCents,
   status,
+  isSharedCourse,
   title,
   unsupportedLessonCount,
 }: CourseSettingsDrawerProps) {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<SettingsTab>(SETTINGS_TABS.SETTINGS);
+  const [activeTab, setActiveTab] = useState<SettingsTab>(
+    isSharedCourse ? SETTINGS_TABS.STATUS : SETTINGS_TABS.SETTINGS,
+  );
   const courseTabs = useEditCourseTabs();
   const visibleCourseTabValues = new Set(courseTabs.map((tab) => tab.value));
 
   const tabs: Array<{ label: string; value: SettingsTab }> = [
-    { label: title, value: SETTINGS_TABS.SETTINGS },
+    ...(!isSharedCourse ? [{ label: title, value: SETTINGS_TABS.SETTINGS }] : []),
     { label: t("adminCourseView.common.status"), value: SETTINGS_TABS.STATUS },
-    ...(visibleCourseTabValues.has(EDIT_COURSE_TABS.PRICING)
+    ...(!isSharedCourse && visibleCourseTabValues.has(EDIT_COURSE_TABS.PRICING)
       ? [{ label: t("adminCourseView.common.pricing"), value: SETTINGS_TABS.PRICING }]
       : []),
     ...(visibleCourseTabValues.has(EDIT_COURSE_TABS.ENROLLED)
@@ -76,7 +80,7 @@ export default function CourseSettingsDrawer({
           },
         ]
       : []),
-    ...(visibleCourseTabValues.has(EDIT_COURSE_TABS.EXPORTS)
+    ...(!isSharedCourse && visibleCourseTabValues.has(EDIT_COURSE_TABS.EXPORTS)
       ? [
           {
             label: t("adminCourseView.sharedCourse.exportsTitle"),
@@ -123,7 +127,7 @@ export default function CourseSettingsDrawer({
             </div>
 
             <div className="min-w-0 flex-1 overflow-auto p-4 md:p-6">
-              {activeTab === SETTINGS_TABS.SETTINGS && (
+              {activeTab === SETTINGS_TABS.SETTINGS && !isSharedCourse && (
                 <CourseSettingsSwitches courseId={courseId} />
               )}
               {activeTab === SETTINGS_TABS.STATUS && (

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseWhatYouWillLearn.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseWhatYouWillLearn.test.tsx
@@ -1,4 +1,4 @@
-import { MAX_COURSE_LEARNING_OUTCOMES } from "@repo/shared";
+import { COURSE_ORIGIN_TYPES, MAX_COURSE_LEARNING_OUTCOMES } from "@repo/shared";
 import { screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -64,6 +64,28 @@ describe("CourseWhatYouWillLearn", () => {
     expect(screen.getByText("Clean data")).toBeInTheDocument();
     expect(screen.getByText("Build dashboards")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add learning outcome" })).not.toBeInTheDocument();
+  });
+
+  it("renders shared-course learning outcomes without editing controls", () => {
+    mockedIsAdminExperience = true;
+    mockedCourse = createCourse({
+      learningOutcomes: ["Centrally managed outcome"],
+      originType: COURSE_ORIGIN_TYPES.EXPORTED,
+    });
+
+    renderWith().render(
+      <CourseWhatYouWillLearn
+        courseOutcomes={["Centrally managed outcome"]}
+        language="en"
+        idOrSlug="course-1"
+      />,
+    );
+
+    expect(screen.getByText("Centrally managed outcome")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add learning outcome" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove learning outcome" }),
+    ).not.toBeInTheDocument();
   });
 
   it("lets admins add a learning outcome and saves it for the current language", async () => {

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseWhatYouWillLearn.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseWhatYouWillLearn.tsx
@@ -1,4 +1,8 @@
-import { MAX_COURSE_LEARNING_OUTCOMES, type SupportedLanguages } from "@repo/shared";
+import {
+  COURSE_ORIGIN_TYPES,
+  MAX_COURSE_LEARNING_OUTCOMES,
+  type SupportedLanguages,
+} from "@repo/shared";
 import { Check, CheckCircle2, Plus, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,6 +34,7 @@ export default function CourseWhatYouWillLearn({
 }: CourseWhatYouWillLearnProps) {
   const { t } = useTranslation();
   const { course, isAdminExperience } = useCourseAccessProvider();
+  const canEdit = isAdminExperience && course.originType !== COURSE_ORIGIN_TYPES.EXPORTED;
   const { mutateAsync: updateCourse, isPending } = useUpdateCourse();
 
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
@@ -46,7 +51,7 @@ export default function CourseWhatYouWillLearn({
     inputRefs.current[editingOutcomeIndex]?.focus();
   }, [editingOutcomeIndex]);
 
-  if (!isAdminExperience && courseOutcomes.length === 0) {
+  if (!canEdit && courseOutcomes.length === 0) {
     return null;
   }
 
@@ -118,7 +123,7 @@ export default function CourseWhatYouWillLearn({
         <span className="min-w-0 flex-1 whitespace-nowrap">
           {t("modernCourseView.overview.whatYouWillMaster")}
         </span>
-        {isAdminExperience && (
+        {canEdit && (
           <>
             <span className="text-lg font-medium text-white/80">
               {outcomesDraft.length}/{MAX_COURSE_LEARNING_OUTCOMES}
@@ -171,18 +176,16 @@ export default function CourseWhatYouWillLearn({
             ) : (
               <button
                 type="button"
-                disabled={!isAdminExperience || isPending}
+                disabled={!canEdit || isPending}
                 onClick={() => {
-                  if (isAdminExperience) {
-                    setEditingOutcomeIndex(index);
-                  }
+                  if (canEdit) setEditingOutcomeIndex(index);
                 }}
                 className={cn(
                   "min-h-7 flex-1 rounded-lg border-2 border-dashed border-transparent px-2 py-0.5 text-left text-base font-medium leading-6 text-white transition-all",
                   {
                     "cursor-pointer focus-visible:border-white focus-visible:bg-white focus-visible:bg-opacity-10 focus-visible:outline-none":
-                      isAdminExperience,
-                    "cursor-default disabled:opacity-100": !isAdminExperience,
+                      canEdit,
+                    "cursor-default disabled:opacity-100": !canEdit,
                   },
                 )}
               >
@@ -190,7 +193,7 @@ export default function CourseWhatYouWillLearn({
               </button>
             )}
 
-            {isAdminExperience && editingOutcomeIndex !== index && (
+            {canEdit && editingOutcomeIndex !== index && (
               <button
                 type="button"
                 onPointerDown={(event) => {

--- a/apps/web/app/modules/Courses/CourseView/TableOfContent/TableOfContent.tsx
+++ b/apps/web/app/modules/Courses/CourseView/TableOfContent/TableOfContent.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@remix-run/react";
-import { PERMISSIONS, type SupportedLanguages } from "@repo/shared";
+import { COURSE_ORIGIN_TYPES, PERMISSIONS, type SupportedLanguages } from "@repo/shared";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -59,6 +59,7 @@ export function TableOfContent({ language }: TableOfContentProps) {
     hasPermission(permissions, PERMISSIONS.COURSE_STATISTICS);
   const shouldShowTabs = isAdminExperience || canShowChat || canShowStatistics;
   const hasMissingTranslations = missingTranslationsResponse?.data.hasMissingTranslations ?? false;
+  const canEditContent = isAdminExperience && course.originType !== COURSE_ORIGIN_TYPES.EXPORTED;
 
   const navigateToCourseEditor = () => {
     navigate(`/admin/beta-courses/${course.id}`);
@@ -75,7 +76,7 @@ export function TableOfContent({ language }: TableOfContentProps) {
       {shouldShowTabs && (
         <CourseOverviewTabs
           activeTab={activeTab}
-          canEditContent={isAdminExperience}
+          canEditContent={canEditContent}
           canShowChat={canShowChat}
           canShowStatistics={canShowStatistics}
           hasMissingTranslations={hasMissingTranslations}

--- a/apps/web/app/modules/Profile/Certificates/certificateTheme.test.ts
+++ b/apps/web/app/modules/Profile/Certificates/certificateTheme.test.ts
@@ -26,5 +26,6 @@ describe("certificateTheme", () => {
   it("returns default theme when certificate color is missing", () => {
     expect(getCertificateColorTheme(null)).toEqual(defaultCertificateColorTheme);
     expect(getCertificateColorTheme(undefined)).toEqual(defaultCertificateColorTheme);
+    expect(defaultCertificateColorTheme.titleColor).toBe("#000000");
   });
 });

--- a/apps/web/e2e/factories/course.factory.ts
+++ b/apps/web/e2e/factories/course.factory.ts
@@ -38,6 +38,7 @@ export class CourseFactory {
       language: input.language ?? "en",
       status: input.status ?? "draft",
       thumbnailS3Key: input.thumbnailS3Key,
+      learningOutcomes: input.learningOutcomes,
       priceInCents: input.priceInCents,
       currency: input.currency,
       isScorm: input.isScorm,

--- a/apps/web/e2e/factories/course.factory.ts
+++ b/apps/web/e2e/factories/course.factory.ts
@@ -86,6 +86,18 @@ export class CourseFactory {
     return response.data.data;
   }
 
+  async shareWithTenant(id: string, targetTenantId: string) {
+    return this.apiClient.api.courseControllerExportMasterCourse(id, {
+      targetTenantIds: [targetTenantId],
+    });
+  }
+
+  async getMasterCourseExports(id: string) {
+    const response = await this.apiClient.api.courseControllerGetMasterCourseExports(id);
+
+    return response.data.data;
+  }
+
   async updateHasCertificate(id: string, hasCertificate: boolean) {
     await this.apiClient.api.courseControllerUpdateHasCertificate(id, { hasCertificate });
     return this.getById(id);

--- a/apps/web/e2e/specs/courses/shared-course-overview.spec.ts
+++ b/apps/web/e2e/specs/courses/shared-course-overview.spec.ts
@@ -1,0 +1,134 @@
+import { USER_ROLE } from "~/config/userRoles";
+
+import {
+  COURSE_OVERVIEW_HANDLES,
+  COURSE_SETTINGS_HANDLES,
+  COURSE_TAB_VALUES,
+  EDIT_COURSE_PAGE_HANDLES,
+} from "../../data/courses/handles";
+import { expect, test } from "../../fixtures/test.fixture";
+import { openCourseOverviewSettingsFlow } from "../../flows/courses/open-course-overview-settings.flow";
+import { openCourseOverviewFlow } from "../../flows/learning/open-course-overview.flow";
+
+test("shared course metadata and learning outcomes are read-only for recipient admins", async ({
+  cleanup,
+  factories,
+  createIsolatedWorkspace,
+  withWorkerPage,
+}) => {
+  const recipientWorkspace = await createIsolatedWorkspace({ role: USER_ROLE.admin });
+  let targetCourseId = "";
+
+  await withWorkerPage(
+    USER_ROLE.admin,
+    async () => {
+      const categoryFactory = factories.createCategoryFactory();
+      const courseFactory = factories.createCourseFactory();
+      const category = await categoryFactory.create(`Shared Course Category ${Date.now()}`);
+      const sourceCourse = await courseFactory.create({
+        categoryId: category.id,
+        description: "Centrally managed description",
+        title: `Shared Course ${Date.now()}`,
+      });
+
+      await courseFactory.update(sourceCourse.id, {
+        language: "en",
+        learningOutcomes: ["Centrally managed learning outcome"],
+      });
+
+      cleanup.add(async () => {
+        await courseFactory.delete(sourceCourse.id);
+        await categoryFactory.delete(category.id);
+      });
+
+      await courseFactory.shareWithTenant(sourceCourse.id, recipientWorkspace.tenant.id);
+
+      await expect
+        .poll(
+          async () => {
+            const exports = await courseFactory.getMasterCourseExports(sourceCourse.id);
+            targetCourseId = exports[0]?.targetCourseId ?? "";
+            return targetCourseId || null;
+          },
+          { timeout: 30_000 },
+        )
+        .not.toBeNull();
+    },
+    { root: true },
+  );
+
+  await expect
+    .poll(
+      async () => {
+        if (!targetCourseId) return null;
+
+        try {
+          const course = await recipientWorkspace.apiClient.api.courseControllerGetBetaCourseById({
+            id: targetCourseId,
+            language: "en",
+          });
+          return course.data.data.originType;
+        } catch {
+          return null;
+        }
+      },
+      { timeout: 30_000 },
+    )
+    .toBe("exported");
+
+  await openCourseOverviewFlow(recipientWorkspace.page, targetCourseId);
+
+  await expect(
+    recipientWorkspace.page.getByTestId(COURSE_OVERVIEW_HANDLES.EDIT_MEDIA_BUTTON),
+  ).toHaveCount(0);
+  await expect(
+    recipientWorkspace.page.getByTestId(COURSE_SETTINGS_HANDLES.TITLE_INPUT),
+  ).toHaveCount(0);
+  await expect(
+    recipientWorkspace.page.getByTestId(COURSE_SETTINGS_HANDLES.CATEGORY_SELECT),
+  ).toBeDisabled();
+  await expect(
+    recipientWorkspace.page.getByText("Centrally managed learning outcome"),
+  ).toBeVisible();
+  await expect(
+    recipientWorkspace.page.getByRole("button", { name: "Add learning outcome" }),
+  ).toHaveCount(0);
+  await expect(
+    recipientWorkspace.page.getByRole("button", { name: "Remove learning outcome" }),
+  ).toHaveCount(0);
+  await expect(recipientWorkspace.page.getByRole("button", { name: "Edit content" })).toHaveCount(
+    0,
+  );
+
+  await recipientWorkspace.page.getByTestId(EDIT_COURSE_PAGE_HANDLES.LANGUAGE_SELECT).click();
+  await expect(
+    recipientWorkspace.page.getByTestId(EDIT_COURSE_PAGE_HANDLES.languageOption("de")),
+  ).toHaveCount(0);
+
+  await openCourseOverviewSettingsFlow(recipientWorkspace.page, targetCourseId);
+  await expect(
+    recipientWorkspace.page.getByTestId(
+      COURSE_OVERVIEW_HANDLES.settingsTab(COURSE_TAB_VALUES.STATUS.toLowerCase()),
+    ),
+  ).toBeVisible();
+  await expect(
+    recipientWorkspace.page.getByTestId(
+      COURSE_OVERVIEW_HANDLES.settingsTab(COURSE_TAB_VALUES.ENROLLED.toLowerCase()),
+    ),
+  ).toBeVisible();
+  await expect(
+    recipientWorkspace.page.getByTestId(
+      COURSE_OVERVIEW_HANDLES.settingsTab(COURSE_TAB_VALUES.SETTINGS.toLowerCase()),
+    ),
+  ).toHaveCount(0);
+  await expect(
+    recipientWorkspace.page.getByTestId(
+      COURSE_OVERVIEW_HANDLES.settingsTab(COURSE_TAB_VALUES.PRICING.toLowerCase()),
+    ),
+  ).toHaveCount(0);
+  await expect(
+    recipientWorkspace.page.getByTestId(
+      COURSE_OVERVIEW_HANDLES.settingsTab(COURSE_TAB_VALUES.EXPORTS.toLowerCase()),
+    ),
+  ).toHaveCount(0);
+});

--- a/apps/web/e2e/specs/courses/shared-course-overview.spec.ts
+++ b/apps/web/e2e/specs/courses/shared-course-overview.spec.ts
@@ -28,12 +28,8 @@ test("shared course metadata and learning outcomes are read-only for recipient a
       const sourceCourse = await courseFactory.create({
         categoryId: category.id,
         description: "Centrally managed description",
-        title: `Shared Course ${Date.now()}`,
-      });
-
-      await courseFactory.update(sourceCourse.id, {
-        language: "en",
         learningOutcomes: ["Centrally managed learning outcome"],
+        title: `Shared Course ${Date.now()}`,
       });
 
       cleanup.add(async () => {
@@ -87,9 +83,6 @@ test("shared course metadata and learning outcomes are read-only for recipient a
   await expect(
     recipientWorkspace.page.getByTestId(COURSE_SETTINGS_HANDLES.CATEGORY_SELECT),
   ).toBeDisabled();
-  await expect(
-    recipientWorkspace.page.getByText("Centrally managed learning outcome"),
-  ).toBeVisible();
   await expect(
     recipientWorkspace.page.getByRole("button", { name: "Add learning outcome" }),
   ).toHaveCount(0);

--- a/docs/specs/course-sharing-business-spec.md
+++ b/docs/specs/course-sharing-business-spec.md
@@ -4,7 +4,7 @@
 
 Course sharing lets a managing organization distribute one centrally maintained course to other organizations without rebuilding or manually updating the training in every tenant. HR and L&D teams can keep one authoritative curriculum while each recipient organization controls when its local copy is published and who is enrolled.
 
-The managing-tenant administrator selects recipient organizations from the course editor and shares the course. Mentingo creates a read-only draft copy in each selected organization, then automatically synchronizes later content changes from the source. Recipient administrators can publish the shared course and manage enrollment without gaining access to alter centrally owned content.
+The managing-tenant administrator selects recipient organizations from the course editor and shares the course. Mentingo creates a read-only draft copy in each selected organization, then automatically synchronizes later content changes from the source, including learner-facing course metadata and the “what you’ll learn” section. Recipient administrators can publish the shared course, manage enrollment, and configure certificate settings without gaining access to alter centrally owned content.
 
 ## Who Uses It
 
@@ -32,7 +32,7 @@ Central course ownership reduces duplicated authoring and makes training updates
 
 A managing-tenant administrator opens a course's sharing area, selects one or more active organizations, and starts sharing. Inactive organizations are omitted from the selector and cannot be supplied directly through the API. Mentingo creates a separate draft course for each recipient and copies the supported curriculum and resources in the background. The source becomes the centrally managed master, while recipient copies display a shared-course notice and restrict editing to the local controls that remain available, including status and enrollment.
 
-When the source course or its curriculum changes, Mentingo queues synchronization for every active sharing link. The recipient copy receives the latest centrally managed content but keeps its existing draft or published status. A later sync therefore updates what learners see without making a locally published course unavailable.
+When the source course or its curriculum changes, Mentingo queues synchronization for every active sharing link. The recipient copy receives the latest centrally managed content and learner-facing metadata but keeps its existing draft or published status. A later sync therefore updates what learners see without making a locally published course unavailable. In the recipient’s course overview, centrally owned metadata such as the title, category, description, cover, trailer, and learning outcomes is presented as read-only; local administrators retain controls for rollout, enrollment, and certificate settings.
 
 ## Key Technical Context
 
@@ -46,4 +46,4 @@ When the source course or its curriculum changes, Mentingo queues synchronizatio
 
 API E2E coverage verifies managing-tenant authorization, active-recipient selection, rejection of inactive recipients, initial draft creation, read-only exported content, localized course/category copying, repeated sharing behavior, resource and video handling, category synchronization, and source deletion propagation. Regression coverage also verifies that after a recipient publishes its shared copy, a later source update synchronizes content without changing that published status.
 
-There is no dedicated Playwright E2E flow for tenant-to-tenant course sharing; the UI workflow and local controls are evidenced by the course editor implementation and translations rather than browser-level coverage.
+Frontend Playwright coverage verifies that recipient administrators see shared-course metadata and learning outcomes as read-only, cannot open the content editor or add new languages, and retain only the allowed settings tabs.

--- a/packages/shared/src/utils/certificate.ts
+++ b/packages/shared/src/utils/certificate.ts
@@ -11,15 +11,17 @@ export interface CertificateRenderTheme {
   logoColor: string;
 }
 
+export const DEFAULT_CERTIFICATE_FONT_COLOR = "#000000";
+
 export const defaultCertificateRenderTheme: CertificateRenderTheme = {
-  titleColor: "#1f2937",
-  certifyTextColor: "#374151",
-  nameColor: "#1f2937",
-  courseNameColor: "#1f2937",
-  bodyTextColor: "#4b5563",
-  labelTextColor: "#1f2937",
+  titleColor: DEFAULT_CERTIFICATE_FONT_COLOR,
+  certifyTextColor: DEFAULT_CERTIFICATE_FONT_COLOR,
+  nameColor: DEFAULT_CERTIFICATE_FONT_COLOR,
+  courseNameColor: DEFAULT_CERTIFICATE_FONT_COLOR,
+  bodyTextColor: DEFAULT_CERTIFICATE_FONT_COLOR,
+  labelTextColor: DEFAULT_CERTIFICATE_FONT_COLOR,
   lineColor: "#9ca3af",
-  logoColor: "#1f2937",
+  logoColor: DEFAULT_CERTIFICATE_FONT_COLOR,
 };
 
 export type BuildCertificateMarkupOptions = {


### PR DESCRIPTION
## Issue(s)
[1904 - Fix shared course metadata being editable](https://github.com/Selleo/mentingo/issues/1904)

## Overview

Make exported/shared courses read-only for centrally managed content while preserving recipient-admin controls for course rollout, enrollment, and certificate settings.

The change:

- Hides metadata, media, learning outcome, content editor, and add-language controls for exported courses.
- Keeps existing language selection available without allowing new languages to be added.
- Allows exported-course certificate settings, including signature upload and font color.
- Defaults certificate font color to black.
- Adds frontend unit and Playwright E2E coverage for the shared-course restrictions.

## Business Value

Ensures shared-course content remains consistent with the managing organization’s source course and cannot be overwritten by recipient administrators. Recipient organizations retain the controls needed to publish courses, manage learners, and configure certificates locally.

## Screenshots / Video
<img width="1401" height="736" alt="image" src="https://github.com/user-attachments/assets/da9054f0-d81a-436d-896f-e5b879223b65" />