### PR TITLE
chore: improve the look of To-do and AI Mentor tiles on the dashboard

### DIFF
--- a/apps/web/app/modules/Dashboard/Home/widgets/student-ai-mentor-practice.tsx
+++ b/apps/web/app/modules/Dashboard/Home/widgets/student-ai-mentor-practice.tsx
@@ -369,8 +369,8 @@ export function WidgetStudentAiMentorPractice({
             onRetry={() => void refetch()}
           />
         ) : !data ? (
-          <div className="flex min-h-0 flex-1 flex-col justify-between gap-4 p-4 sm:p-5">
-            <div className="max-w-2xl">
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 sm:gap-4 sm:p-4">
+            <div className="max-w-2xl shrink-0">
               <p className="body-base-md text-neutral-950">
                 {t("dashboardHome.widgets.studentTiles.aiMentorPractice.emptyPrompt")}
               </p>
@@ -378,7 +378,7 @@ export function WidgetStudentAiMentorPractice({
                 {t("aiMentorPractice.form.scenarioHint")}
               </p>
             </div>
-            <div className="mt-auto w-full">
+            <div className="mt-auto w-full shrink-0">
               <ScenarioComposer
                 compact={scenarioMaxRows === 1}
                 currentPlaceholder={

--- a/apps/web/app/modules/Dashboard/Home/widgets/todo-tasks.tsx
+++ b/apps/web/app/modules/Dashboard/Home/widgets/todo-tasks.tsx
@@ -67,7 +67,7 @@ function SortableTask({ task, compact, onToggle, onSave, onDelete }: SortableTas
       onPointerDown={(event) => event.stopPropagation()}
       onKeyDown={(event) => event.stopPropagation()}
       className={cn(
-        "group flex items-center gap-2 rounded-lg border border-neutral-100",
+        "group flex items-start gap-2 rounded-lg border border-neutral-100",
         compact ? "px-2 py-1" : "px-2.5 py-2",
       )}
     >
@@ -87,7 +87,7 @@ function SortableTask({ task, compact, onToggle, onSave, onDelete }: SortableTas
 
       <button
         type="button"
-        className="cursor-grab touch-none text-neutral-400 hover:text-neutral-700 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-300 focus-visible:ring-offset-2"
+        className="mt-0.5 cursor-grab touch-none text-neutral-400 hover:text-neutral-700 active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-300 focus-visible:ring-offset-2"
         {...attributes}
         {...listeners}
         aria-label={t("dashboardHome.widgets.todoTasks.reorder")}
@@ -114,7 +114,7 @@ function SortableTask({ task, compact, onToggle, onSave, onDelete }: SortableTas
       ) : (
         <span
           className={cn(
-            "min-w-0 flex-1 truncate text-sm",
+            "min-w-0 flex-1 break-words text-sm leading-5",
             task.completed && "text-neutral-400 line-through",
           )}
         >


### PR DESCRIPTION
## Issue(s)

- #1945 

## Overview

Improve the dashboard experience on smaller screens:

- Allow longer To-do task titles to wrap across multiple lines instead of truncating them.
- Align the To-do task content with the drag handle and keep the handle control positioned consistently.
- Prevent the empty AI Mentor Practice widget state from overflowing short 2×2 dashboard tiles by tightening its spacing and enabling internal scrolling.

## Business Value

Learners can read their complete To-do items and use the dashboard comfortably on smaller laptop screens. AI Mentor Practice remains usable without clipped guidance or an inaccessible scenario composer.

## Screenshots / Video
<img width="477" height="316" alt="image" src="https://github.com/user-attachments/assets/0cad1854-fb80-4973-9642-34bd8f1f67cf" />
<img width="268" height="269" alt="image" src="https://github.com/user-attachments/assets/474e674a-f4e1-4d73-9115-8495d1d9b132" />
