### PR TITLE
fix: keep resource library buttons responsive while videos are uploading

### DIFF
--- a/apps/web/app/hooks/useTusScormUpload.ts
+++ b/apps/web/app/hooks/useTusScormUpload.ts
@@ -26,6 +26,5 @@ export const useTusScormUpload = () => {
   return {
     uploadScormPackage,
     isUploading: tusUpload.isUploading,
-    uploadProgress: tusUpload.uploadProgress,
   };
 };

--- a/apps/web/app/hooks/useTusUpload.ts
+++ b/apps/web/app/hooks/useTusUpload.ts
@@ -18,7 +18,6 @@ export const useTusUpload = () => {
   const { toast } = useToast();
 
   const [isUploading, setIsUploading] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
   const uploadFile = useCallback(
     async <TSession extends TusUploadSession>({
@@ -56,7 +55,6 @@ export const useTusUpload = () => {
       }
 
       setIsUploading(true);
-      setUploadProgress(0);
 
       try {
         await new Promise<void>((resolve, reject) => {
@@ -86,7 +84,6 @@ export const useTusUpload = () => {
             onProgress: (bytesUploaded, bytesTotal) => {
               if (bytesTotal === 0) return;
               const progress = Math.round((bytesUploaded / bytesTotal) * 100);
-              setUploadProgress(progress);
               onProgress?.(progress);
             },
             onError: (error) => {
@@ -119,7 +116,6 @@ export const useTusUpload = () => {
         });
       } finally {
         setIsUploading(false);
-        setUploadProgress(null);
       }
     },
     [t, toast],
@@ -128,6 +124,5 @@ export const useTusUpload = () => {
   return {
     uploadFile,
     isUploading,
-    uploadProgress,
   };
 };

--- a/apps/web/app/hooks/useTusVideoUpload.ts
+++ b/apps/web/app/hooks/useTusVideoUpload.ts
@@ -91,6 +91,5 @@ export const useTusVideoUpload = () => {
     getSessionForFile,
     uploadVideo,
     isUploading: tusUpload.isUploading,
-    uploadProgress: tusUpload.uploadProgress,
   };
 };


### PR DESCRIPTION
## Issue(s)
- #1921 

## Overview

Prevents unnecessary re-renders of the Resource Library while a TUS upload is in progress. Upload progress continues to be delivered through the existing progress callbacks, while the unused React progress state is no longer updated on every upload event.

This keeps Resource Library action buttons visually stable during video uploads. The shared upload state remains available for tracking whether an upload is active, and upload notifications continue to work.

## Business Value

Authors can monitor uploads in the Resource Library without distracting button flicker or unstable hover states, making the content-authoring experience clearer and more reliable.