### PR TITLE
fix: prevent course overview hero image from flickering

### DIFF
--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseHeroImage.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseHeroImage.test.tsx
@@ -4,15 +4,27 @@ import { describe, expect, it } from "vitest";
 import CourseHeroImage from "./CourseHeroImage";
 
 describe("CourseHeroImage", () => {
-  it("allows the mobile hero to grow with its content", () => {
+  it("keeps the hero landscape at mobile and desktop breakpoints", () => {
     render(<CourseHeroImage alt="Course hero" />);
 
     const hero = screen.getByRole("img", { name: "Course hero" }).parentElement;
 
+    expect(hero).toHaveClass("aspect-video");
     expect(hero).toHaveClass("min-h-[22rem]");
     expect(hero).toHaveClass("md:aspect-[21/9]");
-    expect(hero).not.toHaveClass("aspect-[4/3]");
-    expect(hero).not.toHaveClass("min-h-[32rem]");
-    expect(hero).not.toHaveClass("min-[360px]:min-h-[30rem]");
+  });
+
+  it("keeps a placeholder visible behind the course image while it loads", () => {
+    render(<CourseHeroImage alt="Course hero" imagePosition={25} imageUrl="/course-image.jpg" />);
+
+    const hero = screen.getByRole("img", { name: "Course hero" });
+    const image = hero.querySelector("img");
+
+    expect(image).not.toBeNull();
+    expect(image).toHaveAttribute("src", "/course-image.jpg");
+    expect(image).toHaveStyle({ objectPosition: "center 25%" });
+    expect(hero).toHaveStyle({
+      backgroundImage: expect.stringContaining("radial-gradient"),
+    });
   });
 });

--- a/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseHeroImage.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseOverview/CourseHeroImage.tsx
@@ -16,18 +16,27 @@ export default function CourseHeroImage({
   imageUrl,
 }: CourseHeroImageProps) {
   return (
-    <div className="group relative grid min-h-[22rem] w-full min-w-0 max-w-full grid-cols-[minmax(0,1fr)] overflow-hidden sm:min-h-0 md:aspect-[21/9]">
+    <div className="group relative grid aspect-video min-h-[22rem] w-full min-w-0 max-w-full grid-cols-[minmax(0,1fr)] overflow-hidden sm:min-h-0 md:aspect-[21/9]">
       <div
         role="img"
         aria-label={alt}
         style={{
-          backgroundImage: imageUrl
-            ? `url(${JSON.stringify(imageUrl)})`
-            : COURSE_HERO_PLACEHOLDER_BACKGROUND,
+          backgroundImage: COURSE_HERO_PLACEHOLDER_BACKGROUND,
           backgroundPosition: `center ${imagePosition}%`,
         }}
         className="absolute inset-0 size-full bg-cover bg-no-repeat"
-      />
+      >
+        {imageUrl && (
+          <img
+            src={imageUrl}
+            alt=""
+            aria-hidden="true"
+            loading="eager"
+            className="size-full object-cover"
+            style={{ objectPosition: `center ${imagePosition}%` }}
+          />
+        )}
+      </div>
 
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-[rgba(0,0,0,0.7)] via-[rgba(0,0,0,0.2)] to-[rgba(0,0,0,0.1)]" />
 


### PR DESCRIPTION
## Issue(s)
- #1919 

## Overview

Updated the course overview hero image rendering to prevent visual flicker while the image loads. The existing gradient placeholder remains visible behind an eagerly loaded image, and the image keeps the configured vertical position.

The hero now uses landscape aspect-ratio styling while preserving the mobile minimum height required for course controls and long titles.

Added component tests covering the responsive sizing and stable placeholder/image behavior.

## Business Value

Provides a steadier, more polished course overview experience and keeps course hero imagery consistently presented across screen sizes. This reduces visual distraction for learners and course administrators when opening a course.

## Screenshots / Video

<img width="1056" height="456" alt="image" src="https://github.com/user-attachments/assets/242ce8cc-f332-477c-ba67-de1ccb01dcfd" />
