### PR TITLE
fix: correct group manager statistics for more accurate reporting

### DIFF
--- a/apps/api/src/ai/ai.controller.ts
+++ b/apps/api/src/ai/ai.controller.ts
@@ -104,7 +104,7 @@ export class AiController {
   }
 
   @Get("thread/messages")
-  @RequirePermission(PERMISSIONS.AI_USE)
+  @RequirePermission(PERMISSIONS.AI_USE, PERMISSIONS.MANAGED_GROUP_RESULTS_READ)
   @Validate({
     request: [{ type: "query" as const, name: "thread", schema: UUIDSchema }],
     response: baseResponse(Type.Array(responseThreadMessageSchema)),

--- a/apps/api/src/ai/repositories/ai.repository.ts
+++ b/apps/api/src/ai/repositories/ai.repository.ts
@@ -40,6 +40,7 @@ import {
   chapters,
   courses,
   groups,
+  groupManagerGroups,
   groupUsers,
   lessons,
   studentCourses,
@@ -110,6 +111,23 @@ export class AiRepository {
       .where(and(...conditions));
 
     return thread;
+  }
+
+  async isLearnerManagedByUser(learnerId: UUIDType, managerUserId: UUIDType) {
+    const [managedLearner] = await this.db
+      .select({ id: groupUsers.id })
+      .from(groupUsers)
+      .innerJoin(
+        groupManagerGroups,
+        and(
+          eq(groupManagerGroups.groupId, groupUsers.groupId),
+          eq(groupManagerGroups.managerUserId, managerUserId),
+        ),
+      )
+      .where(eq(groupUsers.userId, learnerId))
+      .limit(1);
+
+    return Boolean(managedLearner);
   }
 
   async findLessonIdByThreadId(threadId: UUIDType) {

--- a/apps/api/src/ai/services/ai.service.ts
+++ b/apps/api/src/ai/services/ai.service.ts
@@ -154,6 +154,10 @@ export class AiService {
     )();
   }
 
+  async getExistingThreadForLesson(lessonId: UUIDType, userId: UUIDType) {
+    return this.threadService.findExistingThreadForLesson(lessonId, userId);
+  }
+
   async getPracticeThreadWithSetup(data: {
     practiceSessionId: UUIDType;
     userId: UUIDType;

--- a/apps/api/src/ai/services/thread.service.ts
+++ b/apps/api/src/ai/services/thread.service.ts
@@ -40,6 +40,16 @@ export class ThreadService {
     return { thread: newThread, newThread: true };
   }
 
+  async findExistingThreadForLesson(lessonId: UUIDType, userId: UUIDType) {
+    const aiMentorLessonId = await this.findAiMentorLessonIdFromLesson(lessonId);
+
+    return this.aiRepository.findThread([
+      eq(aiMentorThreads.aiMentorLessonId, aiMentorLessonId),
+      inArray(aiMentorThreads.status, [THREAD_STATUS.ACTIVE, THREAD_STATUS.COMPLETED]),
+      eq(aiMentorThreads.userId, userId),
+    ]);
+  }
+
   async findThread(
     threadId: UUIDType,
     currentUser: ThreadViewer,
@@ -62,7 +72,10 @@ export class ThreadService {
     const author = await this.aiRepository.getCourseAuthorByLesson(lessonId);
 
     const canManageUsers = hasPermission(currentUser.permissions, PERMISSIONS.USER_MANAGE);
-    const hasAccess = canManageUsers || author === userId;
+    const isManagedLearner =
+      hasPermission(currentUser.permissions, PERMISSIONS.MANAGED_GROUP_RESULTS_READ) &&
+      (await this.aiRepository.isLearnerManagedByUser(thread.userId, userId));
+    const hasAccess = canManageUsers || author === userId || isManagedLearner;
 
     if (!(thread.userId === userId || hasAccess))
       throw new ForbiddenException("common.toast.noAccess");

--- a/apps/api/src/certificates/__tests__/certificates.controller.e2e-spec.ts
+++ b/apps/api/src/certificates/__tests__/certificates.controller.e2e-spec.ts
@@ -18,6 +18,7 @@ import { createCourseFactory } from "../../../test/factory/course.factory";
 import { createGroupFactory } from "../../../test/factory/group.factory";
 import { createSettingsFactory } from "../../../test/factory/settings.factory";
 import { createUserFactory } from "../../../test/factory/user.factory";
+import { assignSystemRoleToUserInTests } from "../../../test/helpers/permission-role-helpers";
 import { cookieFor, truncateAllTables } from "../../../test/helpers/test-helpers";
 import { ACTIVITY_LOG_ACTION_TYPES } from "../../activity-logs/types";
 import { DEFAULT_PAGE_SIZE } from "../../common/pagination";
@@ -27,6 +28,7 @@ import {
   activityLogs,
   certificates,
   chapters,
+  groupManagerGroups,
   lessons,
   questions,
   studentChapterProgress,
@@ -1491,6 +1493,159 @@ describe("CertificatesController (e2e)", () => {
     });
   });
 
+  describe("GET /api/certificates/course/:courseId", () => {
+    it("returns all course certificate rows for an administrator", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const firstStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create();
+      const secondStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create();
+      const cookies = await cookieFor(admin, app);
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        title: "Course certificate statistics",
+        authorId: admin.id,
+        categoryId: category.id,
+        thumbnailS3Key: null,
+        hasCertificate: true,
+      });
+
+      await db.insert(studentCourses).values([
+        { studentId: firstStudent.id, courseId: course.id, status: "enrolled" },
+        { studentId: secondStudent.id, courseId: course.id, status: "enrolled" },
+      ]);
+      await db.insert(certificates).values([
+        { userId: firstStudent.id, courseId: course.id },
+        { userId: secondStudent.id, courseId: course.id },
+      ]);
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/certificates/course/${course.id}`)
+        .set("Cookie", cookies)
+        .query({ language: "en" })
+        .expect(200);
+
+      expect(response.body.data.data).toHaveLength(2);
+      expect(response.body.data.pagination.totalItems).toBe(2);
+    });
+
+    it("returns an empty result for an empty group and filters rows for a populated group", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const student = await userFactory.withCredentials({ password }).withUserSettings(db).create();
+      const cookies = await cookieFor(admin, app);
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        title: "Filtered certificate statistics",
+        authorId: admin.id,
+        categoryId: category.id,
+        thumbnailS3Key: null,
+        hasCertificate: true,
+      });
+      const populatedGroup = await groupFactory.withMembers([student.id]).create();
+      const emptyGroup = await groupFactory.create();
+
+      await db.insert(studentCourses).values({
+        studentId: student.id,
+        courseId: course.id,
+        status: "enrolled",
+      });
+      await db.insert(certificates).values({ userId: student.id, courseId: course.id });
+
+      const emptyResponse = await request(app.getHttpServer())
+        .get(`/api/certificates/course/${course.id}`)
+        .set("Cookie", cookies)
+        .query({ language: "en", groupId: emptyGroup.id })
+        .expect(200);
+
+      expect(emptyResponse.body.data.data).toEqual([]);
+      expect(emptyResponse.body.data.pagination.totalItems).toBe(0);
+
+      const populatedResponse = await request(app.getHttpServer())
+        .get(`/api/certificates/course/${course.id}`)
+        .set("Cookie", cookies)
+        .query({ language: "en", groupId: populatedGroup.id })
+        .expect(200);
+
+      expect(populatedResponse.body.data.data).toHaveLength(1);
+      expect(populatedResponse.body.data.data[0].learnerEmail).toBe(student.email);
+      expect(populatedResponse.body.data.pagination.totalItems).toBe(1);
+    });
+
+    it("returns only learners in groups managed by a group manager", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .withAdminRole()
+        .create();
+      const manager = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create({ roleSlug: SYSTEM_ROLE_SLUGS.GROUP_MANAGER, tenantId: admin.tenantId });
+      await assignSystemRoleToUserInTests(
+        db,
+        manager.id,
+        manager.tenantId,
+        SYSTEM_ROLE_SLUGS.GROUP_MANAGER,
+      );
+      const managedStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create();
+      const unmanagedStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create();
+      const cookies = await cookieFor(manager, app);
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        title: "Managed certificate statistics",
+        authorId: admin.id,
+        categoryId: category.id,
+        thumbnailS3Key: null,
+        hasCertificate: true,
+      });
+      const managedGroup = await groupFactory.withMembers([managedStudent.id]).create();
+      const unmanagedGroup = await groupFactory.withMembers([unmanagedStudent.id]).create();
+
+      await db.insert(groupManagerGroups).values({
+        managerUserId: manager.id,
+        groupId: managedGroup.id,
+        tenantId: manager.tenantId,
+      });
+      await db.insert(studentCourses).values([
+        { studentId: managedStudent.id, courseId: course.id, status: "enrolled" },
+        { studentId: unmanagedStudent.id, courseId: course.id, status: "enrolled" },
+      ]);
+      await db.insert(certificates).values([
+        { userId: managedStudent.id, courseId: course.id },
+        { userId: unmanagedStudent.id, courseId: course.id },
+      ]);
+
+      const response = await request(app.getHttpServer())
+        .get(`/api/certificates/course/${course.id}`)
+        .set("Cookie", cookies)
+        .query({ language: "en" })
+        .expect(200);
+
+      expect(response.body.data.data).toHaveLength(1);
+      expect(response.body.data.data[0].learnerEmail).toBe(managedStudent.email);
+      expect(response.body.data.data[0].learnerEmail).not.toBe(unmanagedStudent.email);
+      expect(unmanagedGroup.id).toBeDefined();
+    });
+  });
+
   describe("POST /api/certificates/download", () => {
     describe("when user is not logged in", () => {
       it("returns 401 if user is not logged in", async () => {
@@ -1578,6 +1733,97 @@ describe("CertificatesController (e2e)", () => {
           "attachment; filename=\"Python Basics.pdf\"; filename*=UTF-8''Python%20Basics.pdf",
         );
         expect(response.body instanceof Buffer).toBe(true);
+      });
+
+      it("allows a group manager to download a managed learner certificate", async () => {
+        const admin = await userFactory
+          .withCredentials({ password })
+          .withAdminSettings(db)
+          .withAdminRole()
+          .create();
+        const manager = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create({ roleSlug: SYSTEM_ROLE_SLUGS.GROUP_MANAGER, tenantId: admin.tenantId });
+        await assignSystemRoleToUserInTests(
+          db,
+          manager.id,
+          manager.tenantId,
+          SYSTEM_ROLE_SLUGS.GROUP_MANAGER,
+        );
+        const student = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create();
+        const cookies = await cookieFor(manager, app);
+        const category = await categoryFactory.create();
+        const course = await courseFactory.create({
+          title: "Managed certificate download",
+          authorId: admin.id,
+          categoryId: category.id,
+          thumbnailS3Key: null,
+          hasCertificate: true,
+        });
+        const group = await groupFactory.withMembers([student.id]).create();
+        await db.insert(groupManagerGroups).values({
+          managerUserId: manager.id,
+          groupId: group.id,
+          tenantId: manager.tenantId,
+        });
+        const [certificate] = await db
+          .insert(certificates)
+          .values({ userId: student.id, courseId: course.id })
+          .returning();
+
+        const response = await request(app.getHttpServer())
+          .post("/api/certificates/download")
+          .set("Cookie", cookies)
+          .send({ certificateId: certificate.id, language: "en" })
+          .expect(201);
+
+        expect(response.headers["content-type"]).toBe("application/pdf");
+        expect(response.body instanceof Buffer).toBe(true);
+      });
+
+      it("does not allow a group manager to download an unmanaged learner certificate", async () => {
+        const admin = await userFactory
+          .withCredentials({ password })
+          .withAdminSettings(db)
+          .withAdminRole()
+          .create();
+        const manager = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create({ roleSlug: SYSTEM_ROLE_SLUGS.GROUP_MANAGER, tenantId: admin.tenantId });
+        await assignSystemRoleToUserInTests(
+          db,
+          manager.id,
+          manager.tenantId,
+          SYSTEM_ROLE_SLUGS.GROUP_MANAGER,
+        );
+        const student = await userFactory
+          .withCredentials({ password })
+          .withUserSettings(db)
+          .create();
+        const cookies = await cookieFor(manager, app);
+        const category = await categoryFactory.create();
+        const course = await courseFactory.create({
+          title: "Restricted certificate download",
+          authorId: admin.id,
+          categoryId: category.id,
+          thumbnailS3Key: null,
+          hasCertificate: true,
+        });
+        const [certificate] = await db
+          .insert(certificates)
+          .values({ userId: student.id, courseId: course.id })
+          .returning();
+
+        await request(app.getHttpServer())
+          .post("/api/certificates/download")
+          .set("Cookie", cookies)
+          .send({ certificateId: certificate.id, language: "en" })
+          .expect(404);
       });
 
       it("returns 400 when html content is empty", async () => {

--- a/apps/api/src/certificates/certificate.repository.ts
+++ b/apps/api/src/certificates/certificate.repository.ts
@@ -113,6 +113,7 @@ export class CertificateRepository {
     courseId: UUIDType,
     learnerScope: SQL | undefined,
     language: SupportedLanguages,
+    groupId?: UUIDType,
     search?: string,
     page = 1,
     perPage = 20,
@@ -145,6 +146,17 @@ export class CertificateRepository {
         )
       : undefined;
 
+    const groupCondition = groupId
+      ? exists(
+          this.db
+            .select({ id: groupUsers.id })
+            .from(groupUsers)
+            .where(
+              and(eq(groupUsers.userId, studentCourses.studentId), eq(groupUsers.groupId, groupId)),
+            ),
+        )
+      : undefined;
+
     const matchedLearners = this.db
       .select({
         studentCourseId: studentCourses.id,
@@ -162,6 +174,7 @@ export class CertificateRepository {
           eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
           isNull(users.deletedAt),
           learnerScope,
+          groupCondition,
           searchCondition,
         ),
       )
@@ -180,6 +193,7 @@ export class CertificateRepository {
           eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
           isNull(users.deletedAt),
           learnerScope,
+          groupCondition,
           searchCondition,
         ),
       );
@@ -194,12 +208,14 @@ export class CertificateRepository {
           eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
           isNull(users.deletedAt),
           learnerScope,
+          groupCondition,
         ),
       );
 
     const queryRows = await this.db
       .select({
         studentCourseId: matchedLearners.studentCourseId,
+        certificateId: certificates.id,
         learnerName: sql<string | null>`
           CASE
             WHEN ${matchedLearners.studentCourseId} IS NULL THEN NULL
@@ -459,10 +475,11 @@ export class CertificateRepository {
     return certificate;
   }
 
-  async findOwnedCertificateByIdForRender(
-    userId: string,
+  async findCertificateByIdForRender(
+    userId: string | null,
     certificateId: string,
     language: SupportedLanguages,
+    learnerScope?: SQL,
   ) {
     const [certificate] = await this.db
       .select({
@@ -490,9 +507,10 @@ export class CertificateRepository {
       .where(
         and(
           eq(certificates.id, certificateId),
-          eq(certificates.userId, userId),
+          userId ? eq(certificates.userId, userId) : undefined,
           eq(certificates.status, CERTIFICATE_STATUSES.ACTIVE),
           isNull(users.deletedAt),
+          learnerScope,
         ),
       );
 

--- a/apps/api/src/certificates/certificates.controller.ts
+++ b/apps/api/src/certificates/certificates.controller.ts
@@ -66,6 +66,7 @@ export class CertificatesController {
     request: [
       { type: "param", name: "courseId", schema: UUIDSchema },
       { type: "query", name: "language", schema: supportedLanguagesSchema },
+      { type: "query", name: "groupId", schema: Type.Optional(UUIDSchema) },
       { type: "query", name: "search", schema: Type.Optional(Type.String()) },
       { type: "query", name: "page", schema: Type.Optional(Type.Number({ minimum: 1 })) },
       { type: "query", name: "perPage", schema: Type.Optional(Type.Number({ minimum: 1 })) },
@@ -75,6 +76,7 @@ export class CertificatesController {
   async getCourseCertificateRows(
     @Param("courseId") courseId: UUIDType,
     @Query("language") language: SupportedLanguages,
+    @Query("groupId") groupId: UUIDType | undefined,
     @Query("search") search: string | undefined,
     @Query("page") page = 1,
     @Query("perPage") perPage = 20,
@@ -85,6 +87,7 @@ export class CertificatesController {
         courseId,
         language,
         currentUser,
+        groupId,
         search,
         page,
         perPage,
@@ -180,7 +183,7 @@ export class CertificatesController {
   }
 
   @Post("download")
-  @RequirePermission(PERMISSIONS.CERTIFICATE_RENDER)
+  @RequirePermission(PERMISSIONS.CERTIFICATE_RENDER, PERMISSIONS.MANAGED_GROUP_RESULTS_READ)
   @Validate({
     request: [{ type: "body", schema: downloadCertificateSchema }],
   })
@@ -194,7 +197,7 @@ export class CertificatesController {
     const requestBaseUrl = getRequestBaseUrl(req);
 
     const { pdfBuffer, filename } = await this.certificatesService.downloadCertificate(
-      currentUser.userId,
+      currentUser,
       certificateId,
       language,
       requestBaseUrl,

--- a/apps/api/src/certificates/certificates.schema.ts
+++ b/apps/api/src/certificates/certificates.schema.ts
@@ -98,6 +98,7 @@ export const certificateDashboardSummarySchema = Type.Object({
 export const courseCertificateStatusSchema = Type.Enum(COURSE_CERTIFICATE_STATUSES);
 
 export const courseCertificateRowSchema = Type.Object({
+  certificateId: Type.Union([UUIDSchema, Type.Null()]),
   learnerName: Type.String(),
   learnerEmail: Type.String(),
   groups: Type.Array(Type.String()),

--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -50,7 +50,7 @@ import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { S3Service } from "src/s3/s3.service";
 import { SettingsService } from "src/settings/settings.service";
 import { DB, DB_ADMIN } from "src/storage/db/db.providers";
-import { courses, studentCourses } from "src/storage/schema";
+import { certificates, courses, studentCourses } from "src/storage/schema";
 
 import { CertificateRepository } from "./certificate.repository";
 import {
@@ -186,6 +186,7 @@ export class CertificatesService implements OnModuleDestroy {
     courseId: UUIDType,
     language: SupportedLanguages,
     currentUser: CurrentUserType,
+    groupId?: UUIDType,
     search?: string,
     page?: number,
     perPage?: number,
@@ -198,18 +199,15 @@ export class CertificatesService implements OnModuleDestroy {
       [PERMISSIONS.COURSE_STATISTICS],
     );
 
-    const { rows, hasScopedLearner, totalItems } =
-      await this.certificateRepository.getCourseCertificateRows(
-        courseId,
-        learnerScope,
-        language,
-        search,
-        page ?? 1,
-        perPage ?? DEFAULT_PAGE_SIZE,
-      );
-
-    if (learnerScope && !hasScopedLearner)
-      throw new NotFoundException("adminCourseView.errors.notFound.course");
+    const { rows, totalItems } = await this.certificateRepository.getCourseCertificateRows(
+      courseId,
+      learnerScope,
+      language,
+      groupId,
+      search,
+      page ?? 1,
+      perPage ?? DEFAULT_PAGE_SIZE,
+    );
 
     const certificateSignature = rows[0]?.certificateSignature;
     const certificateSignatureUrl = certificateSignature
@@ -580,16 +578,20 @@ export class CertificatesService implements OnModuleDestroy {
   }
 
   async downloadCertificate(
-    userId: UUIDType,
+    currentUser: CurrentUserType,
     certificateId: UUIDType,
     language?: SupportedLanguages,
     baseUrl?: string | null,
   ): Promise<{ pdfBuffer: Buffer; filename: string }> {
     const shareLanguage = this.normalizeLanguage(language);
-    const certificate = await this.certificateRepository.findOwnedCertificateByIdForRender(
-      userId,
+    const learnerScope = getGroupManagerLearnerScopeCondition(currentUser, certificates.userId, [
+      PERMISSIONS.COURSE_STATISTICS,
+    ]);
+    const certificate = await this.certificateRepository.findCertificateByIdForRender(
+      learnerScope ? null : currentUser.userId,
       certificateId,
       shareLanguage,
+      learnerScope,
     );
 
     if (!certificate?.tenantId) {

--- a/apps/api/src/certificates/certificates.service.ts
+++ b/apps/api/src/certificates/certificates.service.ts
@@ -24,7 +24,7 @@ import {
   isSupportedLanguage,
 } from "@repo/shared";
 import { addDays, addMonths, addYears, format } from "date-fns";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { escape } from "lodash";
 import puppeteer, { type Page, type Browser } from "puppeteer";
 import { match } from "ts-pattern";
@@ -37,6 +37,7 @@ import { resolveTenantOrigin } from "src/common/helpers/resolveTenantOrigin";
 import { DEFAULT_PAGE_SIZE, parsePagination } from "src/common/pagination";
 import { canUpdateCourseByAuthor } from "src/common/permissions/course-permission.utils";
 import {
+  getGroupManagerCourseScopeCondition,
   getGroupManagerLearnerScopeCondition,
   shouldApplyGroupManagerScope,
 } from "src/common/permissions/group-manager-scope.utils";
@@ -170,7 +171,14 @@ export class CertificatesService implements OnModuleDestroy {
     const [course] = await this.db
       .select({ authorId: courses.authorId })
       .from(courses)
-      .where(eq(courses.id, courseId));
+      .where(
+        and(
+          eq(courses.id, courseId),
+          getGroupManagerCourseScopeCondition(currentUser, courses.id, [
+            PERMISSIONS.COURSE_STATISTICS,
+          ]),
+        ),
+      );
 
     if (!course) throw new NotFoundException("adminCourseView.errors.notFound.course");
 

--- a/apps/api/src/common/permissions/__tests__/group-manager.e2e-spec.ts
+++ b/apps/api/src/common/permissions/__tests__/group-manager.e2e-spec.ts
@@ -392,12 +392,19 @@ describe("Group Manager authorization outcomes (e2e)", () => {
       .set("Cookie", cookie)
       .expect(200);
 
-    expect(learningTimeResponse.body.data.users).toEqual([
-      expect.objectContaining({
-        id: fixture.assignedLearner.id,
-        totalSeconds: 120,
-      }),
-    ]);
+    expect(learningTimeResponse.body.data.users).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: fixture.assignedLearner.id,
+          totalSeconds: 120,
+        }),
+        expect.objectContaining({
+          id: notStartedLearner.id,
+          totalSeconds: 0,
+        }),
+      ]),
+    );
+    expect(learningTimeResponse.body.data.users).toHaveLength(2);
   });
 
   it("scopes quiz and AI Mentor outcomes to authorized learners", async () => {
@@ -703,7 +710,7 @@ describe("Group Manager authorization outcomes (e2e)", () => {
       .expect(200);
   });
 
-  it("lists every certificate outcome without identifiers or download permission", async () => {
+  it("lists every certificate outcome with identifiers and download permission", async () => {
     const activeLearner = await createUser("active-certificate");
     const expiredLearner = await createUser("expired-certificate");
     const revokedLearner = await createUser("revoked-certificate");
@@ -769,7 +776,11 @@ describe("Group Manager authorization outcomes (e2e)", () => {
       [expiredLearner.email]: COURSE_CERTIFICATE_STATUSES.EXPIRED,
       [revokedLearner.email]: COURSE_CERTIFICATE_STATUSES.REVOKED,
     });
-    expect(response.body.data.data.every((row: object) => !("certificateId" in row))).toBe(true);
+    expect(
+      response.body.data.data.find(
+        (row: { learnerEmail: string }) => row.learnerEmail === activeLearner.email,
+      ).certificateId,
+    ).toBe(activeCertificate.id);
     expect(fileServiceMock.getFileUrl).toHaveBeenCalledTimes(1);
     expect(fileServiceMock.getFileUrl).toHaveBeenCalledWith("certificate-signature.png");
     expect(
@@ -782,7 +793,7 @@ describe("Group Manager authorization outcomes (e2e)", () => {
       .post("/api/certificates/download")
       .set("Cookie", cookie)
       .send({ certificateId: activeCertificate.id, language: "en" })
-      .expect(403);
+      .expect(201);
   });
 
   it("exports only authorized learner rows and only shared managed-group names", async () => {

--- a/apps/api/src/common/permissions/group-manager-scope.utils.ts
+++ b/apps/api/src/common/permissions/group-manager-scope.utils.ts
@@ -1,7 +1,7 @@
 import { COURSE_ENROLLMENT, LIVE_TRAINING_LINK_ENTITY_TYPES, PERMISSIONS } from "@repo/shared";
 import { and, eq, sql } from "drizzle-orm";
 
-import { groupManagerGroups } from "src/storage/schema";
+import { groupCourses, groupManagerGroups } from "src/storage/schema";
 
 import { hasAnyPermission, hasPermission } from "./permission.utils";
 
@@ -60,13 +60,24 @@ export const getGroupManagerCourseScopeCondition = (
 
   return sql`EXISTS (
     SELECT 1
-    FROM student_courses sc_scope
-    INNER JOIN group_users gu_scope ON gu_scope.user_id = sc_scope.student_id
-    INNER JOIN group_manager_groups gmg_scope ON gmg_scope.group_id = gu_scope.group_id
+    FROM ${groupManagerGroups} gmg_scope
     WHERE gmg_scope.manager_user_id = ${currentUser.userId}
       AND gmg_scope.tenant_id = ${currentUser.tenantId}
-      AND sc_scope.course_id = ${courseId}
-      AND sc_scope.status = ${COURSE_ENROLLMENT.ENROLLED}
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM ${groupCourses} gc_scope
+          WHERE gc_scope.group_id = gmg_scope.group_id
+            AND gc_scope.course_id = ${courseId}
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM student_courses sc_scope
+          INNER JOIN group_users gu_scope ON gu_scope.user_id = sc_scope.student_id
+          WHERE gu_scope.group_id = gmg_scope.group_id
+            AND sc_scope.course_id = ${courseId}
+        )
+      )
   )`;
 };
 

--- a/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
+++ b/apps/api/src/courses/__tests__/course.controller.e2e-spec.ts
@@ -35,6 +35,7 @@ import {
   coursesSummaryStats,
   courseStudentsStats,
   groupCourses,
+  groupManagerGroups,
   lessonLearningTime,
   lessons,
   resourceEntity,
@@ -52,6 +53,7 @@ import { createCourseFactory } from "../../../test/factory/course.factory";
 import { createGroupFactory } from "../../../test/factory/group.factory";
 import { createSettingsFactory } from "../../../test/factory/settings.factory";
 import { createUserFactory } from "../../../test/factory/user.factory";
+import { assignSystemRoleToUserInTests } from "../../../test/helpers/permission-role-helpers";
 import { cookieFor, truncateTables } from "../../../test/helpers/test-helpers";
 
 import type { CalendarEventTestResponse } from "./types/calendar-event-test.types";
@@ -452,6 +454,182 @@ describe("CourseController (e2e)", () => {
         .query({ language: SUPPORTED_LANGUAGES.EN })
         .set("Cookie", await cookieFor(admin, app))
         .expect(200);
+    });
+  });
+
+  describe("course statistics group manager scope", () => {
+    it("limits every statistics endpoint to the manager's assigned groups", async () => {
+      const admin = await userFactory
+        .withCredentials({ password })
+        .withAdminSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.ADMIN });
+      const manager = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create({ role: SYSTEM_ROLE_SLUGS.GROUP_MANAGER, tenantId: admin.tenantId });
+      await assignSystemRoleToUserInTests(
+        db,
+        manager.id,
+        manager.tenantId,
+        SYSTEM_ROLE_SLUGS.GROUP_MANAGER,
+      );
+      const managedStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create({ tenantId: admin.tenantId });
+      const unmanagedStudent = await userFactory
+        .withCredentials({ password })
+        .withUserSettings(db)
+        .create({ tenantId: admin.tenantId });
+      const category = await categoryFactory.create();
+      const course = await courseFactory.create({
+        authorId: admin.id,
+        categoryId: category.id,
+        title: "Group manager statistics scope",
+        chapterCount: 1,
+      });
+      const chapter = await chapterFactory.create({
+        authorId: admin.id,
+        courseId: course.id,
+        title: "Statistics scope chapter",
+        displayOrder: 1,
+        lessonCount: 1,
+      });
+      const [quiz] = await db
+        .insert(lessons)
+        .values({
+          chapterId: chapter.id,
+          type: LESSON_TYPES.QUIZ,
+          title: buildJsonbField(SUPPORTED_LANGUAGES.EN, "Statistics scope quiz"),
+          description: buildJsonbField(SUPPORTED_LANGUAGES.EN, ""),
+          thresholdScore: 0,
+          displayOrder: 1,
+        })
+        .returning();
+      const managedGroup = await groupFactory
+        .withMembers([managedStudent.id])
+        .create({ tenantId: admin.tenantId });
+      const unmanagedGroup = await groupFactory
+        .withMembers([unmanagedStudent.id])
+        .create({ tenantId: admin.tenantId });
+
+      await db.insert(groupManagerGroups).values({
+        managerUserId: manager.id,
+        groupId: managedGroup.id,
+        tenantId: manager.tenantId,
+      });
+      await db.insert(coursesSummaryStats).values({
+        courseId: course.id,
+        authorId: admin.id,
+        freePurchasedCount: 1,
+        completedCourseStudentCount: 1,
+      });
+      await db.insert(studentCourses).values([
+        {
+          studentId: managedStudent.id,
+          courseId: course.id,
+          status: COURSE_ENROLLMENT.ENROLLED,
+          progress: "completed",
+          completedAt: new Date().toISOString(),
+        },
+        {
+          studentId: unmanagedStudent.id,
+          courseId: course.id,
+          status: COURSE_ENROLLMENT.ENROLLED,
+          progress: "completed",
+          completedAt: new Date().toISOString(),
+        },
+      ]);
+      await db.insert(studentLessonProgress).values([
+        {
+          studentId: managedStudent.id,
+          chapterId: chapter.id,
+          lessonId: quiz.id,
+          quizScore: 80,
+          attempts: 1,
+          isStarted: true,
+          isQuizPassed: true,
+          completedAt: new Date().toISOString(),
+        },
+        {
+          studentId: unmanagedStudent.id,
+          chapterId: chapter.id,
+          lessonId: quiz.id,
+          quizScore: 20,
+          attempts: 1,
+          isStarted: true,
+          isQuizPassed: true,
+          completedAt: new Date().toISOString(),
+        },
+      ]);
+      await db.insert(lessonLearningTime).values([
+        {
+          userId: managedStudent.id,
+          lessonId: quiz.id,
+          courseId: course.id,
+          totalSeconds: 120,
+        },
+        {
+          userId: unmanagedStudent.id,
+          lessonId: quiz.id,
+          courseId: course.id,
+          totalSeconds: 240,
+        },
+      ]);
+
+      const cookies = await cookieFor(manager, app);
+      const progressResponse = await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-progress`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200);
+      expect(
+        progressResponse.body.data.map(({ studentId }: { studentId: string }) => studentId),
+      ).toEqual([managedStudent.id]);
+
+      const quizResponse = await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-quiz-results`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200);
+      expect(
+        quizResponse.body.data.map(({ studentId }: { studentId: string }) => studentId),
+      ).toEqual([managedStudent.id]);
+
+      const aiMentorResponse = await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-ai-mentor-results`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200);
+      expect(aiMentorResponse.body.data).toEqual([]);
+
+      const averageResponse = await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/average-quiz-score`)
+        .query({ language: SUPPORTED_LANGUAGES.EN })
+        .set("Cookie", cookies)
+        .expect(200);
+      expect(averageResponse.body.data.averageScoresPerQuiz[0].averageScore).toBe(80);
+
+      const learningTimeResponse = await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/learning-time`)
+        .query({ perPage: 100 })
+        .set("Cookie", cookies)
+        .expect(200);
+      expect(learningTimeResponse.body.data.users.map(({ id }: { id: string }) => id)).toEqual([
+        managedStudent.id,
+      ]);
+
+      const summaryResponse = await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics`)
+        .set("Cookie", cookies)
+        .expect(200);
+      expect(summaryResponse.body.data.enrolledCount).toBe(1);
+
+      await request(app.getHttpServer())
+        .get(`/api/course/${course.id}/statistics/students-progress`)
+        .query({ language: SUPPORTED_LANGUAGES.EN, groupId: unmanagedGroup.id })
+        .set("Cookie", cookies)
+        .expect(404);
     });
   });
 

--- a/apps/api/src/learning-time/learning-time.repository.ts
+++ b/apps/api/src/learning-time/learning-time.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { COURSE_ENROLLMENT, type SupportedLanguages } from "@repo/shared";
-import { and, countDistinct, eq, isNull, ne, sql } from "drizzle-orm";
+import { and, countDistinct, eq, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
 
 import { DatabasePg } from "src/common";
 import { addPagination, DEFAULT_PAGE_SIZE } from "src/common/pagination";
@@ -9,6 +9,7 @@ import { LocalizationService } from "src/localization/localization.service";
 import {
   chapters,
   courses,
+  groupCourses,
   groups,
   groupManagerGroups,
   groupUsers,
@@ -127,11 +128,16 @@ export class LearningTimeRepository {
 
   async getTotalLearningTimePerStudentCount(courseId: UUIDType, conditions: SQL<unknown>[] = []) {
     const [{ totalItems }] = await this.db
-      .select({ totalItems: countDistinct(lessonLearningTime.userId) })
-      .from(lessonLearningTime)
-      .leftJoin(users, eq(users.id, lessonLearningTime.userId))
+      .select({ totalItems: countDistinct(studentCourses.studentId) })
+      .from(studentCourses)
+      .innerJoin(users, eq(users.id, studentCourses.studentId))
       .where(
-        and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt), ...conditions),
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          isNull(users.deletedAt),
+          ...conditions,
+        ),
       );
 
     return totalItems ?? 0;
@@ -176,10 +182,10 @@ export class LearningTimeRepository {
   ) {
     return this.db
       .select({
-        id: lessonLearningTime.userId,
+        id: studentCourses.studentId,
         name: sql<string>`${users.firstName} || ' ' || ${users.lastName}`,
         studentAvatarKey: users.avatarReference,
-        totalSeconds: sql<number>`SUM(${lessonLearningTime.totalSeconds})::INTEGER`,
+        totalSeconds: sql<number>`COALESCE(SUM(${lessonLearningTime.totalSeconds}), 0)::INTEGER`,
         groups: sql<Array<{ id: string; name: string }>>`(
           SELECT json_agg(
             json_build_object(
@@ -196,11 +202,25 @@ export class LearningTimeRepository {
           WHERE ${groupUsers.userId} = ${users.id}
         )`,
       })
-      .from(lessonLearningTime)
-      .innerJoin(users, eq(lessonLearningTime.userId, users.id))
-      .where(and(eq(lessonLearningTime.courseId, courseId), isNull(users.deletedAt), ...conditions))
+      .from(studentCourses)
+      .innerJoin(users, eq(users.id, studentCourses.studentId))
+      .leftJoin(
+        lessonLearningTime,
+        and(
+          eq(lessonLearningTime.userId, studentCourses.studentId),
+          eq(lessonLearningTime.courseId, studentCourses.courseId),
+        ),
+      )
+      .where(
+        and(
+          eq(studentCourses.courseId, courseId),
+          eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
+          isNull(users.deletedAt),
+          ...conditions,
+        ),
+      )
       .groupBy(
-        lessonLearningTime.userId,
+        studentCourses.studentId,
         users.firstName,
         users.lastName,
         users.email,
@@ -234,26 +254,50 @@ export class LearningTimeRepository {
       );
   }
 
-  async getGroupsInCourse(
-    courseId: UUIDType,
+  async getGroupsInCourse(courseId: UUIDType, language?: SupportedLanguages) {
+    return this.db
+      .select({
+        id: groups.id,
+        name: this.localizationService.getLocalizedSqlField(groups.name, language, groups),
+      })
+      .from(groups)
+      .leftJoin(
+        groupCourses,
+        and(eq(groupCourses.groupId, groups.id), eq(groupCourses.courseId, courseId)),
+      )
+      .leftJoin(groupUsers, eq(groupUsers.groupId, groups.id))
+      .leftJoin(
+        studentCourses,
+        and(eq(studentCourses.studentId, groupUsers.userId), eq(studentCourses.courseId, courseId)),
+      )
+      .leftJoin(users, eq(studentCourses.studentId, users.id))
+      .where(
+        and(
+          or(
+            isNotNull(groupCourses.id),
+            and(isNotNull(studentCourses.studentId), isNull(users.deletedAt)),
+          ),
+        ),
+      )
+      .groupBy(groups.id);
+  }
+
+  async getManagedGroups(
+    managerUserId: UUIDType,
+    tenantId: UUIDType,
     language?: SupportedLanguages,
-    conditions: SQL[] = [],
   ) {
     return this.db
       .select({
         id: groups.id,
         name: this.localizationService.getLocalizedSqlField(groups.name, language, groups),
       })
-      .from(studentCourses)
-      .innerJoin(users, eq(studentCourses.studentId, users.id))
-      .innerJoin(groupUsers, eq(users.id, groupUsers.userId))
-      .innerJoin(groups, eq(groupUsers.groupId, groups.id))
+      .from(groupManagerGroups)
+      .innerJoin(groups, eq(groupManagerGroups.groupId, groups.id))
       .where(
         and(
-          eq(studentCourses.courseId, courseId),
-          ne(studentCourses.status, COURSE_ENROLLMENT.NOT_ENROLLED),
-          isNull(users.deletedAt),
-          ...conditions,
+          eq(groupManagerGroups.managerUserId, managerUserId),
+          eq(groupManagerGroups.tenantId, tenantId),
         ),
       )
       .groupBy(groups.id);

--- a/apps/api/src/learning-time/learning-time.service.ts
+++ b/apps/api/src/learning-time/learning-time.service.ts
@@ -7,7 +7,6 @@ import { getSortOptions } from "src/common/helpers/getSortOptions";
 import { getUserNameSearchCondition } from "src/common/helpers/getUserNameSearchCondition";
 import { DEFAULT_PAGE_SIZE } from "src/common/pagination";
 import {
-  getGroupManagerGroupScopeCondition,
   getGroupManagerLearnerScopeCondition,
   shouldApplyGroupManagerScope,
 } from "src/common/permissions/group-manager-scope.utils";
@@ -17,7 +16,7 @@ import { IMAGE_QUALITY } from "src/file/image-variants/image-variant.constants";
 import { LearningTimeRepository } from "src/learning-time/learning-time.repository";
 import { LocalizationService } from "src/localization/localization.service";
 import { QUEUE_NAMES, QueueService } from "src/queue";
-import { groups, groupUsers, lessonLearningTime, users } from "src/storage/schema";
+import { groups, groupUsers, lessonLearningTime, studentCourses, users } from "src/storage/schema";
 import { WsGateway } from "src/websocket";
 
 import type { createCache } from "cache-manager";
@@ -317,7 +316,7 @@ export class LearningTimeService implements OnModuleInit {
     if (currentUser) {
       const managerScope = getGroupManagerLearnerScopeCondition(
         currentUser,
-        lessonLearningTime.userId,
+        studentCourses.studentId,
         [PERMISSIONS.COURSE_STATISTICS],
       );
 
@@ -336,7 +335,7 @@ export class LearningTimeService implements OnModuleInit {
           SELECT 1
           FROM ${groupUsers}
           INNER JOIN ${groups} ON ${groups.id} = ${groupUsers.groupId}
-          WHERE ${groupUsers.userId} = ${lessonLearningTime.userId}
+          WHERE ${groupUsers.userId} = ${studentCourses.studentId}
             AND ${groupNameSearchCondition}
         )`,
       );
@@ -348,7 +347,7 @@ export class LearningTimeService implements OnModuleInit {
 
     if (query.userId || query.groupId) {
       if (!availableUserIds.length) conditions.push(sql`FALSE`);
-      const usersCondition = inArray(lessonLearningTime.userId, availableUserIds);
+      const usersCondition = inArray(studentCourses.studentId, availableUserIds);
       if (availableUserIds.length && usersCondition) {
         conditions.push(usersCondition);
       }
@@ -393,20 +392,14 @@ export class LearningTimeService implements OnModuleInit {
     language?: SupportedLanguages,
     currentUser?: CurrentUserType,
   ) {
-    const conditions: SQL[] = [];
-
-    if (currentUser) {
-      const managerScope = getGroupManagerGroupScopeCondition(currentUser, groups.id, [
-        PERMISSIONS.COURSE_STATISTICS,
-      ]);
-
-      if (managerScope) conditions.push(managerScope);
-    }
-    const groupOptions = await this.learningTimeRepository.getGroupsInCourse(
-      courseId,
-      language,
-      conditions,
-    );
+    const groupOptions =
+      currentUser && shouldApplyGroupManagerScope(currentUser, [PERMISSIONS.COURSE_STATISTICS])
+        ? await this.learningTimeRepository.getManagedGroups(
+            currentUser.userId,
+            currentUser.tenantId,
+            language,
+          )
+        : await this.learningTimeRepository.getGroupsInCourse(courseId, language);
 
     return { groups: groupOptions };
   }

--- a/apps/api/src/lesson/services/lesson.service.ts
+++ b/apps/api/src/lesson/services/lesson.service.ts
@@ -234,6 +234,7 @@ export class LessonService {
     }
 
     if (lesson.type === LESSON_TYPES.AI_MENTOR) {
+      const existingThread = await this.aiService.getExistingThreadForLesson(id, effectiveUserId);
       let avatarUrl = undefined;
 
       if (lesson.aiMentor?.avatarReferenceUrl) {
@@ -248,6 +249,9 @@ export class LessonService {
           name: lesson.aiMentor?.name ?? "AI Mentor",
           avatarReferenceUrl: avatarUrl,
         },
+        threadId: existingThread?.id,
+        userLanguage: existingThread?.userLanguage,
+        status: existingThread?.status,
       } as LessonShow;
     }
 

--- a/apps/api/src/report/report.controller.ts
+++ b/apps/api/src/report/report.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get, Query, Res, UseGuards } from "@nestjs/common";
 import { PERMISSIONS, SupportedLanguages } from "@repo/shared";
+import { Type } from "@sinclair/typebox";
 import { Response } from "express";
 import { Validate } from "nestjs-typebox";
 
+import { UUIDSchema } from "src/common";
 import { RequirePermission } from "src/common/decorators/require-permission.decorator";
 import { CurrentUser } from "src/common/decorators/user.decorator";
 import { PermissionsGuard } from "src/common/guards/permissions.guard";
@@ -19,14 +21,18 @@ export class ReportController {
   @Get("summary")
   @RequirePermission(PERMISSIONS.REPORT_READ, PERMISSIONS.MANAGED_GROUP_RESULTS_READ)
   @Validate({
-    request: [{ type: "query", name: "language", schema: supportedLanguagesSchema }],
+    request: [
+      { type: "query", name: "language", schema: supportedLanguagesSchema },
+      { type: "query", name: "courseId", schema: Type.Optional(UUIDSchema) },
+    ],
   })
   async downloadSummaryReport(
     @Query("language") language: SupportedLanguages,
+    @Query("courseId") courseId: string | undefined,
     @Res() res: Response,
     @CurrentUser() currentUser: CurrentUserType,
   ): Promise<void> {
-    const buffer = await this.reportService.generateSummaryReport(language, currentUser);
+    const buffer = await this.reportService.generateSummaryReport(language, currentUser, courseId);
 
     const filename = `summary-report-${new Date().toISOString().split("T")[0]}.xlsx`;
 

--- a/apps/api/src/report/report.service.ts
+++ b/apps/api/src/report/report.service.ts
@@ -16,8 +16,13 @@ export class ReportService {
   async generateSummaryReport(
     language: SupportedLanguages,
     currentUser: CurrentUserType,
+    courseId?: string,
   ): Promise<Buffer> {
-    const reportData = await this.reportRepository.getAllStudentCourseData(language, currentUser);
+    const reportData = await this.reportRepository.getAllStudentCourseData(
+      language,
+      currentUser,
+      courseId,
+    );
 
     const headers = REPORT_HEADERS[language] || REPORT_HEADERS.en;
 

--- a/apps/api/src/report/repositories/report.repository.ts
+++ b/apps/api/src/report/repositories/report.repository.ts
@@ -43,10 +43,12 @@ export class ReportRepository {
   async getAllStudentCourseData(
     language: SupportedLanguages,
     currentUser: CurrentUserType,
+    courseId?: string,
   ): Promise<StudentCourseReportRow[]> {
     const conditions = [
       eq(studentCourses.status, COURSE_ENROLLMENT.ENROLLED),
       isNull(users.deletedAt),
+      courseId ? eq(studentCourses.courseId, courseId) : undefined,
     ];
 
     const canViewOnlyCreatedCourses = hasPermission(

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -8753,6 +8753,15 @@
             }
           },
           {
+            "name": "groupId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
             "name": "search",
             "required": false,
             "in": "query",
@@ -13769,6 +13778,15 @@
                   "type": "string"
                 }
               ]
+            }
+          },
+          {
+            "name": "courseId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -53873,6 +53891,17 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "certificateId": {
+                      "anyOf": [
+                        {
+                          "format": "uuid",
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
                     "learnerName": {
                       "type": "string"
                     },
@@ -53953,6 +53982,7 @@
                     }
                   },
                   "required": [
+                    "certificateId",
                     "learnerName",
                     "learnerEmail",
                     "groups",

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -7432,6 +7432,7 @@ export interface MarkLessonAsCompletedResponse {
 export interface GetCourseCertificateRowsResponse {
   data: {
     data: {
+      certificateId: string | null;
       learnerName: string;
       learnerEmail: string;
       groups: string[];
@@ -15617,6 +15618,8 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       query?: {
         /** @default "en" */
         language?: "en" | "pl" | "de" | "lt" | "cs" | "es" | "fr";
+        /** @format uuid */
+        groupId?: string;
         search?: string;
         /** @min 1 */
         page?: number;
@@ -17932,6 +17935,8 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       query?: {
         /** @default "en" */
         language?: "en" | "pl" | "de" | "lt" | "cs" | "es" | "fr";
+        /** @format uuid */
+        courseId?: string;
       },
       params: RequestParams = {},
     ) =>

--- a/apps/web/app/api/queries/useCourseCertificateRows.ts
+++ b/apps/web/app/api/queries/useCourseCertificateRows.ts
@@ -9,17 +9,26 @@ export const COURSE_CERTIFICATE_ROWS_QUERY_KEY = "course-certificate-rows";
 export const useCourseCertificateRows = (
   courseId: string,
   language: SupportedLanguages,
+  groupId?: string,
   search?: string,
   page = 1,
   perPage = 20,
   enabled = true,
 ) =>
   useQuery({
-    queryKey: [COURSE_CERTIFICATE_ROWS_QUERY_KEY, courseId, language, search, page, perPage],
+    queryKey: [
+      COURSE_CERTIFICATE_ROWS_QUERY_KEY,
+      courseId,
+      language,
+      groupId,
+      search,
+      page,
+      perPage,
+    ],
     queryFn: async () => {
       const { data } = await ApiClient.api.certificatesControllerGetCourseCertificateRows(
         courseId,
-        { language, search, page, perPage },
+        { language, groupId, search, page, perPage },
       );
       return data.data;
     },

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/CourseAdminStatistics.tsx
@@ -1,4 +1,6 @@
 import { TabsList } from "@radix-ui/react-tabs";
+import { PERMISSIONS } from "@repo/shared";
+import { Download } from "lucide-react";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
@@ -8,6 +10,7 @@ import { useCourseStatisticsFilter } from "~/api/queries/admin/useCourseLearning
 import { useCourseStatistics } from "~/api/queries/admin/useCourseStatistics";
 import { useCourseStudentsAiMentorResults } from "~/api/queries/admin/useCourseStudentsAiMentorResults";
 import { useAIConfigured } from "~/api/queries/useAIConfigured";
+import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import {
   Select,
@@ -18,6 +21,7 @@ import {
 } from "~/components/ui/select";
 import { Tabs, TabsContent, TabsTrigger } from "~/components/ui/tabs";
 import { TooltipProvider } from "~/components/ui/tooltip";
+import { usePermissions } from "~/hooks/usePermissions";
 import { LessonType } from "~/modules/Admin/EditCourse/EditCourse.types";
 import {
   SearchFilter,
@@ -26,6 +30,7 @@ import {
 } from "~/modules/common/SearchFilter/SearchFilter";
 import { CourseStudentsLearningTimeTable } from "~/modules/Courses/CourseView/CourseAdminStatistics/components/CourseStudentsLearningTimeTable";
 import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/LanguageStore";
+import { useDownloadSummaryReport } from "~/modules/Statistics/Admin/hooks/useDownloadSummaryReport";
 
 import { COURSE_STATISTICS_HANDLES } from "../../../../../e2e/data/statistics/handles";
 
@@ -74,6 +79,17 @@ export function CourseAdminStatistics({ course, canManageCourse }: CourseAdminSt
   const { t } = useTranslation();
   const language = useLanguageStore((state) => state.language);
   const courseId = course?.id || "";
+  const { downloadReport, isDownloading } = useDownloadSummaryReport();
+  const { hasAccess: canViewStatistics } = usePermissions({
+    required: [
+      PERMISSIONS.COURSE_UPDATE,
+      PERMISSIONS.COURSE_UPDATE_OWN,
+      PERMISSIONS.MANAGED_GROUP_RESULTS_READ,
+    ],
+  });
+  const { hasAccess: canDownloadCourseReport } = usePermissions({
+    required: [PERMISSIONS.REPORT_READ, PERMISSIONS.MANAGED_GROUP_RESULTS_READ],
+  });
 
   const [groupId, setGroupId] = useState<string | undefined>(undefined);
 
@@ -145,7 +161,7 @@ export function CourseAdminStatistics({ course, canManageCourse }: CourseAdminSt
 
   const { data: aiMentorResultsPreview } = useCourseStudentsAiMentorResults({
     id: courseId,
-    enabled: canManageCourse && Boolean(courseId),
+    enabled: canViewStatistics && Boolean(courseId),
     query: {
       page: 1,
       perPage: 1,
@@ -227,8 +243,9 @@ export function CourseAdminStatistics({ course, canManageCourse }: CourseAdminSt
   const handleGroupFilterChange = (_name: string, value: FilterValue) => {
     const nextGroupId = value as string | undefined;
 
-    setGroupId(nextGroupId);
     startTransition(() => {
+      setGroupId(nextGroupId);
+
       const updateGroupId = <T,>(setter: React.Dispatch<React.SetStateAction<T>>) => {
         setter((prev) => {
           if (!nextGroupId) {
@@ -292,10 +309,25 @@ export function CourseAdminStatistics({ course, canManageCourse }: CourseAdminSt
     <TooltipProvider>
       <Card data-testid={COURSE_STATISTICS_HANDLES.ROOT}>
         <CardHeader>
-          <h6 className="h6">{t("adminCourseView.statistics.title")}</h6>
-          <p className="body-base-md title-neutral-800">
-            {t("adminCourseView.statistics.subtitle")}
-          </p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h6 className="h6">{t("adminCourseView.statistics.title")}</h6>
+              <p className="body-base-md title-neutral-800">
+                {t("adminCourseView.statistics.subtitle")}
+              </p>
+            </div>
+            {canDownloadCourseReport && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void downloadReport(courseId)}
+                disabled={isDownloading}
+              >
+                <Download className="mr-2 size-4" />
+                {t("adminStatisticsView.other.downloadReport")}
+              </Button>
+            )}
+          </div>
         </CardHeader>
 
         <CardContent className="flex flex-col gap-8">
@@ -489,7 +521,11 @@ export function CourseAdminStatistics({ course, canManageCourse }: CourseAdminSt
               />
             </TabsContent>
             <TabsContent value={CourseAdminStatisticsTabs.certificates}>
-              <CourseCertificateRowsTable courseId={courseId} search={certificateSearch} />
+              <CourseCertificateRowsTable
+                courseId={courseId}
+                groupId={groupId}
+                search={certificateSearch}
+              />
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/AverageScorePerQuizChart.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/AverageScorePerQuizChart.tsx
@@ -97,6 +97,7 @@ export function AverageScorePerQuizChart({ averageQuizScores }: AverageScorePerQ
             name={t("adminCourseView.statistics.overview.averageQuizScore")}
             fill="var(--primary)"
             radius={8}
+            maxBarSize={56}
           />
         </BarChart>
       </ChartContainer>

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseCertificateRowsTable.test.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseCertificateRowsTable.test.tsx
@@ -14,6 +14,7 @@ vi.mock("~/api/queries/useCourseCertificateRows", () => ({
     data: {
       data: [
         {
+          certificateId: "certificate-id",
           learnerName: "Alex Learner",
           learnerEmail: "alex@example.com",
           groups: ["Sales"],

--- a/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseCertificateRowsTable.tsx
+++ b/apps/web/app/modules/Courses/CourseView/CourseAdminStatistics/components/CourseCertificateRowsTable.tsx
@@ -25,17 +25,29 @@ import type { ITEMS_PER_PAGE_OPTIONS } from "~/components/Pagination/Pagination"
 
 type CourseCertificateRowsTableProps = {
   courseId: string;
+  groupId?: string;
   search?: string;
 };
 
-export function CourseCertificateRowsTable({ courseId, search }: CourseCertificateRowsTableProps) {
+export function CourseCertificateRowsTable({
+  courseId,
+  groupId,
+  search,
+}: CourseCertificateRowsTableProps) {
   const { t } = useTranslation();
 
   const language = useLanguageStore((state) => state.language);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(20);
 
-  const { data, isFetching } = useCourseCertificateRows(courseId, language, search, page, perPage);
+  const { data, isFetching } = useCourseCertificateRows(
+    courseId,
+    language,
+    groupId,
+    search,
+    page,
+    perPage,
+  );
   const rows = data?.data ?? [];
   const { data: globalSettings } = useGlobalSettings();
   const [preview, setPreview] = useState<CourseCertificateRow | null>(null);
@@ -108,7 +120,7 @@ export function CourseCertificateRowsTable({ courseId, search }: CourseCertifica
 
       <Dialog open={Boolean(preview)} onOpenChange={(open) => !open && setPreview(null)}>
         <DialogContent
-          className="max-w-6xl overflow-hidden p-0"
+          className="flex w-[min(1120px,95vw)] items-center justify-center max-w-none overflow-hidden border-0 bg-transparent p-0 shadow-none"
           noCloseButton
           aria-describedby={undefined}
         >
@@ -118,6 +130,7 @@ export function CourseCertificateRowsTable({ courseId, search }: CourseCertifica
           {preview && (
             <div className="relative">
               <CertificatePreview
+                certificateId={preview.certificateId ?? undefined}
                 studentName={preview.learnerName}
                 courseName={preview.courseTitle}
                 completionDate={preview.issuedAt ?? undefined}
@@ -126,7 +139,7 @@ export function CourseCertificateRowsTable({ courseId, search }: CourseCertifica
                 certificateBackgroundImageUrl={globalSettings?.certificateBackgroundImage}
                 platformLogo={globalSettings?.platformLogoS3Key}
                 initialColor={preview.certificateFontColor}
-                showDownloadButton={false}
+                showDownloadButton={Boolean(preview.certificateId)}
                 showShareButton={false}
                 onClose={() => setPreview(null)}
               />

--- a/apps/web/app/modules/Dashboard/Home/HomeDashboard.page.tsx
+++ b/apps/web/app/modules/Dashboard/Home/HomeDashboard.page.tsx
@@ -1,4 +1,4 @@
-import { DASHBOARD_WIDGET_SIZES, PERMISSIONS, hasPermission } from "@repo/shared";
+import { DASHBOARD_WIDGET_SIZES, PERMISSIONS, hasAnyPermission } from "@repo/shared";
 import { Download, LayoutGrid, Loader2, Settings2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -113,7 +113,10 @@ export default function HomeDashboardPage() {
     useResetDashboardSettings();
   const { downloadReport, isDownloading } = useDownloadSummaryReport();
 
-  const canDownloadReport = hasPermission(currentUser?.permissions ?? [], PERMISSIONS.REPORT_READ);
+  const canDownloadReport = hasAnyPermission(currentUser?.permissions ?? [], [
+    PERMISSIONS.REPORT_READ,
+    PERMISSIONS.MANAGED_GROUP_RESULTS_READ,
+  ]);
 
   const visibleLayout = (isEditing ? draftWidgets : savedWidgets).filter(
     (widget) => widget.visible !== false,

--- a/apps/web/app/modules/Statistics/Admin/hooks/useDownloadSummaryReport.ts
+++ b/apps/web/app/modules/Statistics/Admin/hooks/useDownloadSummaryReport.ts
@@ -17,12 +17,12 @@ export function useDownloadSummaryReport() {
   const { language } = useLanguageStore();
   const [isDownloading, setIsDownloading] = useState(false);
 
-  const downloadReport = async () => {
+  const downloadReport = async (courseId?: string) => {
     setIsDownloading(true);
 
     try {
       const response = (await ApiClient.api.reportControllerDownloadSummaryReport(
-        { language },
+        { language, courseId },
         { format: "blob" },
       )) as unknown as AxiosResponse<Blob>;
 


### PR DESCRIPTION
## Issue(s)
- #1955

## Overview

Implements group-manager scoping for course statistics, certificates, reports, learning time, and AI Mentor results, with backend E2E coverage for the affected access rules.

## Business Value

Gives group managers reliable visibility into the learners and groups they are responsible for, without exposing other groups’ data. It also keeps administrator and content-creator access aligned with their permissions and prevents regressions in reporting, certificates, and AI Mentor workflows.