### PR TITLE
fix: prevent live training issues when settings are changed during an active session

### DIFF
--- a/apps/api/src/live-training/__tests__/live-training.controller.e2e-spec.ts
+++ b/apps/api/src/live-training/__tests__/live-training.controller.e2e-spec.ts
@@ -333,6 +333,26 @@ describe("LiveTrainingController (e2e)", () => {
     expect(calendarEvent.title).toMatchObject({ [language]: "Updated offline training" });
   });
 
+  it("blocks Live Training changes while a session is in progress", async () => {
+    const admin = await createAdmin();
+    const liveTraining = await createOfflineLiveTraining(admin);
+
+    await request(app.getHttpServer())
+      .post(`/api/live-training/${liveTraining.id}/sessions/start`)
+      .query({ language })
+      .set("Cookie", await cookieFor(admin, app))
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/api/live-training/${liveTraining.id}`)
+      .set("Cookie", await cookieFor(admin, app))
+      .send({ language, deliveryType: LIVE_TRAINING_DELIVERY_TYPES.ONLINE })
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.message).toBe("liveTraining.errors.activeSessionUpdateForbidden");
+      });
+  });
+
   it("rejects course links from trainers without course management access", async () => {
     const admin = await createAdmin();
     const trainer = await createTrainer();

--- a/apps/api/src/live-training/live-training.service.ts
+++ b/apps/api/src/live-training/live-training.service.ts
@@ -49,6 +49,7 @@ import { OutboxPublisher } from "src/outbox/outbox.publisher";
 import { DB } from "src/storage/db/db.providers";
 import { calendarEvents, courses, liveTrainingLinks, liveTrainings } from "src/storage/schema";
 
+import { LiveTrainingSessionsRepository } from "./live-training-sessions/live-training-sessions.repository";
 import { LiveTrainingRepository } from "./live-training.repository";
 
 import type {
@@ -84,6 +85,7 @@ export class LiveTrainingService {
     private readonly fileService: FileService,
     private readonly envService: EnvService,
     private readonly outboxPublisher: OutboxPublisher,
+    private readonly liveTrainingSessionsRepository: LiveTrainingSessionsRepository,
   ) {}
 
   async getLiveTrainings(
@@ -532,6 +534,7 @@ export class LiveTrainingService {
     }
 
     this.assertCanDeleteLiveTraining(row.authorId, currentUser);
+    await this.assertNoOpenSession(row.id);
     const linkedLessonCount = await this.liveTrainingRepository.getLinkedLessonCount(row.id);
 
     if (linkedLessonCount > 0) {
@@ -851,7 +854,17 @@ export class LiveTrainingService {
       throw new NotFoundException("liveTraining.errors.notFound");
     }
 
+    await this.assertNoOpenSession(row.id);
+
     return row;
+  }
+
+  private async assertNoOpenSession(id: UUIDType) {
+    const currentSession = await this.liveTrainingSessionsRepository.getCurrentSessionRow(id);
+
+    if (currentSession) {
+      throw new BadRequestException("liveTraining.errors.activeSessionUpdateForbidden");
+    }
   }
 
   private async canSeeLiveTraining(

--- a/apps/web/app/locales/cs/translation.json
+++ b/apps/web/app/locales/cs/translation.json
@@ -921,6 +921,7 @@
       "participants": "Účastníci",
       "viewerMic": "Mikrofon diváka",
       "viewerCamera": "Kamera diváka",
+      "editBlockedDuringSession": "Chcete-li toto nastavení změnit, nejprve ukončete aktuální relaci.",
       "scheduleTooltip": "Plánovaný čas školení",
       "timezoneTooltip": "Časové pásmo školení",
       "maxParticipantsTooltip": "Maximum účastníků",
@@ -5589,6 +5590,8 @@
       "invalidLessonType": "Přiřazení Živé školení lze přidat pouze k lekcím Živé školení.",
       "deleteAssignedToLesson": "Tento Živé školení je propojen s lekcí. Nejdříve smažte lekci a až potom Živé školení.",
       "liveKitNotConfigured": "LiveKit není nakonfigurován.",
+      "liveKitRoomNotAvailable": "Místnost LiveKit pro tuto relaci není dostupná.",
+      "activeSessionUpdateForbidden": "Toto živé školení nelze během probíhající relace měnit.",
       "maxParticipantsReached": "Bylo dosaženo maximálního počtu účastníků.",
       "maxParallelSessionsReached": "Bylo dosaženo maximálního počtu aktivních relací Živé školení."
     }

--- a/apps/web/app/locales/de/translation.json
+++ b/apps/web/app/locales/de/translation.json
@@ -916,6 +916,7 @@
       "participants": "Teilnehmer",
       "viewerMic": "Zuschauermikrofon",
       "viewerCamera": "Zuschauerkamera",
+      "editBlockedDuringSession": "Um diese Einstellung zu ändern, beende zuerst die aktuelle Sitzung.",
       "scheduleTooltip": "Geplante Schulungszeit",
       "timezoneTooltip": "Schulungszeitzone",
       "maxParticipantsTooltip": "Maximale Teilnehmerzahl",
@@ -5581,6 +5582,8 @@
       "invalidLessonType": "Live-Schulungszuweisungen können nur zu Live-Schulungslektionen hinzugefügt werden.",
       "deleteAssignedToLesson": "Dieses Live-Schulung ist mit einer Lektion verknüpft. Lösche zuerst die Lektion, bevor du das Live-Schulung löschst.",
       "liveKitNotConfigured": "LiveKit ist nicht konfiguriert.",
+      "liveKitRoomNotAvailable": "Der LiveKit-Raum für diese Sitzung ist nicht verfügbar.",
+      "activeSessionUpdateForbidden": "Dieses Live-Training kann während einer laufenden Sitzung nicht geändert werden.",
       "maxParticipantsReached": "Die maximale Teilnehmerzahl wurde erreicht.",
       "maxParallelSessionsReached": "Die maximale Anzahl aktiver Live-Schulungssitzungen wurde erreicht."
     }

--- a/apps/web/app/locales/en/translation.json
+++ b/apps/web/app/locales/en/translation.json
@@ -918,6 +918,7 @@
       "participants": "Participants",
       "viewerMic": "Viewer microphone",
       "viewerCamera": "Viewer camera",
+      "editBlockedDuringSession": "To change this setting, end the current session first.",
       "scheduleTooltip": "Planned training time",
       "timezoneTooltip": "Training timezone",
       "maxParticipantsTooltip": "Maximum participants",
@@ -5607,6 +5608,8 @@
       "invalidLessonType": "Only Live Training lessons can have Live Training assignments.",
       "deleteAssignedToLesson": "This Live Training is linked to a lesson. Delete the lesson first before deleting the Live Training.",
       "liveKitNotConfigured": "LiveKit is not configured.",
+      "liveKitRoomNotAvailable": "The LiveKit room for this session is not available.",
+      "activeSessionUpdateForbidden": "This Live Training cannot be changed while a session is in progress.",
       "maxParticipantsReached": "The maximum number of participants has been reached.",
       "maxParallelSessionsReached": "The maximum number of active Live Training sessions has been reached."
     }

--- a/apps/web/app/locales/es/translation.json
+++ b/apps/web/app/locales/es/translation.json
@@ -910,6 +910,7 @@
       "participants": "Participantes",
       "viewerMic": "Micrófono del espectador",
       "viewerCamera": "Cámara del espectador",
+      "editBlockedDuringSession": "Para cambiar este ajuste, primero termina la sesión actual.",
       "scheduleTooltip": "Hora prevista de la formación",
       "timezoneTooltip": "Zona horaria de la formación",
       "maxParticipantsTooltip": "Máximo de participantes",
@@ -5539,6 +5540,8 @@
       "invalidLessonType": "Solo las lecciones de formación en vivo pueden tener asignaciones de formación en vivo.",
       "deleteAssignedToLesson": "Esta formación en vivo está vinculada a una lección. Elimina primero la lección antes de eliminar la formación en vivo.",
       "liveKitNotConfigured": "LiveKit no está configurado.",
+      "liveKitRoomNotAvailable": "La sala de LiveKit para esta sesión no está disponible.",
+      "activeSessionUpdateForbidden": "Esta formación en directo no se puede modificar mientras haya una sesión en curso.",
       "maxParticipantsReached": "Se ha alcanzado el número máximo de participantes.",
       "maxParallelSessionsReached": "Se alcanzó el número máximo de sesiones de formación en vivo activas."
     }

--- a/apps/web/app/locales/fr/translation.json
+++ b/apps/web/app/locales/fr/translation.json
@@ -921,6 +921,7 @@
       "participants": "Participants",
       "viewerMic": "Microphone du spectateur",
       "viewerCamera": "Caméra de visualisation",
+      "editBlockedDuringSession": "Pour modifier ce paramètre, terminez d'abord la session en cours.",
       "scheduleTooltip": "Temps de formation prévu",
       "timezoneTooltip": "Fuseau horaire de la formation",
       "maxParticipantsTooltip": "Nombre maximum de participants",
@@ -5329,6 +5330,8 @@
       "invalidLessonType": "Seules les leçons de formation en direct peuvent avoir des tâches de formation en direct.",
       "deleteAssignedToLesson": "Cette Live Training est liée à une leçon. Supprimez d'abord la leçon avant de supprimer la formation en direct.",
       "liveKitNotConfigured": "LiveKit n'est pas configuré.",
+      "liveKitRoomNotAvailable": "La salle LiveKit de cette session n'est pas disponible.",
+      "activeSessionUpdateForbidden": "Cette formation en direct ne peut pas être modifiée pendant une session en cours.",
       "maxParticipantsReached": "Le nombre maximum de participants a été atteint.",
       "maxParallelSessionsReached": "Le nombre maximum de sessions de formation en direct actives a été atteint."
     }

--- a/apps/web/app/locales/lt/translation.json
+++ b/apps/web/app/locales/lt/translation.json
@@ -915,6 +915,7 @@
       "participants": "Dalyviai",
       "viewerMic": "Žiūrovo mikrofonas",
       "viewerCamera": "Žiūrovo kamera",
+      "editBlockedDuringSession": "Norėdami pakeisti šį nustatymą, pirmiausia užbaikite dabartinę sesiją.",
       "scheduleTooltip": "Planuojamas mokymų laikas",
       "timezoneTooltip": "Mokymų laiko juosta",
       "maxParticipantsTooltip": "Maksimalus dalyvių skaičius",
@@ -5585,6 +5586,8 @@
       "invalidLessonType": "Tiesioginiai mokymai priskyrimus galima pridėti tik prie Tiesioginiai mokymai pamokų.",
       "deleteAssignedToLesson": "Šis Tiesioginiai mokymai susietas su pamoka. Pirmiausia ištrinkite pamoką, tada Tiesioginiai mokymai.",
       "liveKitNotConfigured": "LiveKit nėra sukonfigūruotas.",
+      "liveKitRoomNotAvailable": "Šiai sesijai skirtas LiveKit kambarys nepasiekiamas.",
+      "activeSessionUpdateForbidden": "Šio tiesioginio mokymo negalima keisti, kol vyksta sesija.",
       "maxParticipantsReached": "Pasiektas maksimalus dalyvių skaičius.",
       "maxParallelSessionsReached": "Pasiektas maksimalus aktyvių Tiesioginiai mokymai sesijų skaičius."
     }

--- a/apps/web/app/locales/pl/translation.json
+++ b/apps/web/app/locales/pl/translation.json
@@ -918,6 +918,7 @@
       "participants": "Uczestnicy",
       "viewerMic": "Mikrofon widza",
       "viewerCamera": "Kamera widza",
+      "editBlockedDuringSession": "Aby zmienić to ustawienie, najpierw zakończ bieżącą sesję.",
       "scheduleTooltip": "Planowany czas szkolenia",
       "timezoneTooltip": "Strefa czasowa szkolenia",
       "maxParticipantsTooltip": "Maksymalna liczba uczestników",
@@ -5644,6 +5645,8 @@
       "invalidLessonType": "Przypisania szkolenia na żywo można dodawać tylko do lekcji szkolenia na żywo.",
       "deleteAssignedToLesson": "To szkolenie na żywo jest połączone z lekcją. Najpierw usuń lekcję, a dopiero potem szkolenie na żywo.",
       "liveKitNotConfigured": "LiveKit nie jest skonfigurowany.",
+      "liveKitRoomNotAvailable": "Pokój LiveKit dla tej sesji jest niedostępny.",
+      "activeSessionUpdateForbidden": "Nie można zmieniać tego szkolenia na żywo, gdy sesja jest w toku.",
       "maxParticipantsReached": "Osiągnięto maksymalną liczbę uczestników.",
       "maxParallelSessionsReached": "Osiągnięto maksymalną liczbę aktywnych sesji szkoleń na żywo."
     }

--- a/apps/web/app/modules/LiveTraining/components/LiveTrainingSessionStage.tsx
+++ b/apps/web/app/modules/LiveTraining/components/LiveTrainingSessionStage.tsx
@@ -1,4 +1,8 @@
-import { LIVE_TRAINING_DESCRIPTION_MAX_LENGTH, LIVE_TRAINING_TITLE_MAX_LENGTH } from "@repo/shared";
+import {
+  LIVE_TRAINING_DESCRIPTION_MAX_LENGTH,
+  LIVE_TRAINING_SESSION_STATUSES,
+  LIVE_TRAINING_TITLE_MAX_LENGTH,
+} from "@repo/shared";
 import {
   CalendarClock,
   Mic,
@@ -112,6 +116,12 @@ export function LiveTrainingSessionStage({
     onEditFormStateCommit,
   });
   const canToggleDeliveryType = canEdit && canUseOnlineDelivery;
+  const hasOpenSession =
+    liveTraining.currentSession?.status === LIVE_TRAINING_SESSION_STATUSES.WAITING ||
+    liveTraining.currentSession?.status === LIVE_TRAINING_SESSION_STATUSES.ACTIVE;
+  const editTooltip = hasOpenSession
+    ? t("liveTrainingView.stage.editBlockedDuringSession")
+    : undefined;
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -250,9 +260,10 @@ export function LiveTrainingSessionStage({
                     canEdit={canToggleDeliveryType}
                     value={t(`liveTrainingView.deliveryType.${displayedDeliveryType}`)}
                     tooltip={
-                      canUseOnlineDelivery
+                      editTooltip ??
+                      (canUseOnlineDelivery
                         ? t("calendarView.create.tooltip.deliveryType")
-                        : t("calendarView.create.liveKitRequired")
+                        : t("calendarView.create.liveKitRequired"))
                     }
                   />
                 </button>
@@ -278,7 +289,7 @@ export function LiveTrainingSessionStage({
                             displayedAllDay,
                             language,
                           )}
-                          tooltip={t("liveTrainingView.stage.scheduleTooltip")}
+                          tooltip={editTooltip ?? t("liveTrainingView.stage.scheduleTooltip")}
                         />
                       </button>
                     </PopoverTrigger>
@@ -346,7 +357,7 @@ export function LiveTrainingSessionStage({
                       align="center"
                       className="max-w-xs whitespace-pre-line break-words rounded bg-black px-2 py-1 text-sm text-white shadow-md"
                     >
-                      {t("calendarView.create.tooltip.maxParticipants")}
+                      {editTooltip ?? t("calendarView.create.tooltip.maxParticipants")}
                       <TooltipArrow className="fill-black" />
                     </TooltipContent>
                   </Tooltip>
@@ -382,7 +393,7 @@ export function LiveTrainingSessionStage({
                       align="center"
                       className="max-w-xs whitespace-pre-line break-words rounded bg-black px-2 py-1 text-sm text-white shadow-md"
                     >
-                      {t("calendarView.create.tooltip.location")}
+                      {editTooltip ?? t("calendarView.create.tooltip.location")}
                       <TooltipArrow className="fill-black" />
                     </TooltipContent>
                   </Tooltip>
@@ -413,7 +424,7 @@ export function LiveTrainingSessionStage({
                             : t("liveTrainingView.boolean.no")
                         }
                         variant={editFormState.microphoneEnabled ? "default" : "danger"}
-                        tooltip={t("liveTrainingView.stage.viewerMic")}
+                        tooltip={editTooltip ?? t("liveTrainingView.stage.viewerMic")}
                       />
                     </button>
                     <button
@@ -437,7 +448,7 @@ export function LiveTrainingSessionStage({
                             : t("liveTrainingView.boolean.no")
                         }
                         variant={editFormState.cameraEnabled ? "default" : "danger"}
-                        tooltip={t("liveTrainingView.stage.viewerCamera")}
+                        tooltip={editTooltip ?? t("liveTrainingView.stage.viewerCamera")}
                       />
                     </button>
                   </>

--- a/apps/web/app/modules/LiveTraining/utils/liveTrainingActions.test.ts
+++ b/apps/web/app/modules/LiveTraining/utils/liveTrainingActions.test.ts
@@ -1,4 +1,9 @@
-import { LIVE_TRAINING_DELIVERY_TYPES, LIVE_TRAINING_STATUSES, PERMISSIONS } from "@repo/shared";
+import {
+  LIVE_TRAINING_DELIVERY_TYPES,
+  LIVE_TRAINING_SESSION_STATUSES,
+  LIVE_TRAINING_STATUSES,
+  PERMISSIONS,
+} from "@repo/shared";
 
 import { deriveLiveTrainingUiActions } from "./liveTrainingActions";
 
@@ -13,6 +18,26 @@ const liveTraining = {
 } as unknown as LiveTrainingDetails;
 
 describe("deriveLiveTrainingUiActions", () => {
+  it("blocks editing while a session is waiting or active", () => {
+    const actions = deriveLiveTrainingUiActions({
+      liveTraining: {
+        ...liveTraining,
+        currentSession: { status: LIVE_TRAINING_SESSION_STATUSES.ACTIVE },
+      } as LiveTrainingDetails,
+      currentUserId: "author-id",
+      permissions: [
+        PERMISSIONS.LIVE_TRAINING_UPDATE,
+        PERMISSIONS.LIVE_TRAINING_DELETE,
+        PERMISSIONS.USER_MANAGE,
+      ],
+    });
+
+    expect(actions.canShowEdit).toBe(false);
+    expect(actions.canShowDelete).toBe(false);
+    expect(actions.canEditMaterials).toBe(false);
+    expect(actions.canManagePeople).toBe(false);
+  });
+
   it("allows Group Managers to view scoped session data without session management actions", () => {
     const actions = deriveLiveTrainingUiActions({
       liveTraining,

--- a/apps/web/app/modules/LiveTraining/utils/liveTrainingActions.ts
+++ b/apps/web/app/modules/LiveTraining/utils/liveTrainingActions.ts
@@ -43,7 +43,6 @@ export const deriveLiveTrainingUiActions = ({
   const canUpdateOwn = hasPermission(permissions, PERMISSIONS.LIVE_TRAINING_UPDATE_OWN) && isAuthor;
   const canDeleteAny = hasPermission(permissions, PERMISSIONS.LIVE_TRAINING_DELETE);
   const canDeleteOwn = hasPermission(permissions, PERMISSIONS.LIVE_TRAINING_DELETE_OWN) && isAuthor;
-  const canEditDetails = canUpdateAny || canUpdateOwn || isHost;
   const canManageSession = hasHostRole || hasBroadManagePermission;
   const canViewAllMaterials = hasHostRole || hasBroadManagePermission;
   const canViewSessionData =
@@ -60,6 +59,7 @@ export const deriveLiveTrainingUiActions = ({
   const hasOpenSession =
     currentSession?.status === LIVE_TRAINING_SESSION_STATUSES.WAITING ||
     currentSession?.status === LIVE_TRAINING_SESSION_STATUSES.ACTIVE;
+  const canEditDetails = (canUpdateAny || canUpdateOwn || isHost) && !hasOpenSession;
   const isJoinable =
     liveTraining.deliveryType === LIVE_TRAINING_DELIVERY_TYPES.ONLINE &&
     hasOpenSession &&
@@ -67,7 +67,7 @@ export const deriveLiveTrainingUiActions = ({
 
   return {
     canShowEdit: canEditDetails,
-    canShowDelete: canDeleteAny || canDeleteOwn,
+    canShowDelete: (canDeleteAny || canDeleteOwn) && !hasOpenSession,
     canShowStart:
       (hasPermission(permissions, PERMISSIONS.LIVE_TRAINING_START) || hasHostRole) &&
       canManageSession &&

--- a/docs/specs/live-training-business-spec.md
+++ b/docs/specs/live-training-business-spec.md
@@ -37,7 +37,7 @@ L&D teams can coordinate blended programs more reliably because scheduling, cour
 
 Administrators create a live training item with title, schedule, delivery type, hosts, location or online room behavior, participant visibility, and optional course links. Sessions can also be created from the calendar, which pre-fills scheduling context.
 
-Authorized editors can adjust key session details directly from the Live Training workspace. Valid inline changes, including maximum participant capacity, are saved when the editor leaves the field and are then reflected in the session data and connected calendar views.
+Authorized editors can adjust key session details directly from the Live Training workspace. Valid inline changes, including maximum participant capacity, are saved when the editor leaves the field and are then reflected in the session data and connected calendar views. Once a session is waiting to start or in progress, Mentingo locks Live Training configuration and participant/material management until the session is finished, while hosts retain the controls needed to run it.
 
 When LiveKit is configured, online sessions expose join-room behavior. When it is not configured, online delivery is not selectable and offline sessions remain available. Hosts can start and end sessions. For course-linked offline sessions, ending the session can complete the linked lesson for enrolled learners.
 
@@ -52,6 +52,7 @@ Materials are separated into before-session and after-session resources. Privile
 - API endpoints live under `apps/api/src/live-training`.
 - Access is guarded by the Live Training feature flag plus permissions such as `PERMISSIONS.LIVE_TRAINING_READ`, create/update/delete, join, start, end, and statistics.
 - Live Training integrates with Calendar, course lessons, resource uploads, announcements/email, realtime session updates, and LiveKit online rooms.
+- An open session prevents changes to Live Training configuration, deletion, host assignments, and materials; the API enforces this rule even if a client bypasses the UI.
 - Online room participant layout is handled by the LiveKit-based meeting components in `apps/web/app/modules/LiveTraining/components/LiveTrainingMeeting`.
 
 ## Test Evidence


### PR DESCRIPTION
## Overview

Prevent Live Training configuration changes while a session is waiting or active. The API now rejects updates and deletion during an open session, while the web UI hides editing actions and explains the restriction through contextual tooltips.

Added translations for the LiveKit room error and the active-session update error across all supported locales. Updated the Live Training business specification and added API and frontend test coverage.

## Business Value

This prevents sessions from becoming inconsistent or unusable when delivery settings are changed after the session has started. Trainers can run the current session safely, while users receive clear guidance to end the session before changing its settings.