### PR TITLE
chore: improve drag-and-drop support for uploading multiple files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Start with this file, then read the more specific `AGENTS.md` files for the area
 
 - Run the narrowest relevant validation command for touched code.
 - Update or add tests for changed behavior.
-- When product or feature behavior changes, run `.agents/skills/mentingo-feature-overview/SKILL.md` and update the matching business spec in `docs/specs/<feature-slug>-business-spec.md` as part of the same change. If no spec exists yet, create it.
+- When a change meaningfully alters a product capability, user workflow, access rule, or business outcome, run `.agents/skills/mentingo-feature-overview/SKILL.md` and update the matching business spec in `docs/specs/<feature-slug>-business-spec.md` as part of the same change. If no spec exists yet, create it. Do not update business specs for cosmetic changes, copy or styling adjustments, implementation-only refactors, or small bug fixes that merely restore already-documented intended behavior.
 - Regenerate generated artifacts only through existing scripts.
 - Keep changes limited to the task.
 - Report commands run, commands skipped, assumptions, and remaining risks.

--- a/apps/web/app/components/RichText/Editor.tsx
+++ b/apps/web/app/components/RichText/Editor.tsx
@@ -29,6 +29,7 @@ import { extractUrlFromClipboard } from "./extensions/utils/video";
 import { baseEditorPlugins, boldBulletEditorPlugins, getContentEditorPlugins } from "./plugins";
 import { defaultClasses } from "./styles";
 import EditorToolbar from "./toolbar/EditorToolbar";
+import { uploadDroppedFilesAtPosition } from "./utils/uploadDroppedFiles";
 
 import type { AssetLibraryConfig } from "./components/AssetLibraryDialog";
 
@@ -49,6 +50,7 @@ type EditorProps = {
     file?: File,
     editor?: TiptapEditor | null,
     visibility?: EditableResourceVisibility,
+    position?: number,
   ) => Promise<void>;
   onCtrlSave?: (editor: TiptapEditor | null) => void;
   uploadProgress?: number | null;
@@ -111,13 +113,13 @@ const Editor = ({
 
       const activeEditor = editorRef.current;
       setPendingDrop(null);
-
-      for (const file of pendingDrop.files) {
-        activeEditor?.commands.setTextSelection(pendingDrop.position);
-        activeEditor?.commands.focus();
-        await onUpload(file, activeEditor, visibility);
-        activeEditor?.commands.focus();
-      }
+      await uploadDroppedFilesAtPosition({
+        editor: activeEditor,
+        files: pendingDrop.files,
+        position: pendingDrop.position,
+        visibility,
+        onUpload,
+      });
     },
     [onUpload, pendingDrop],
   );

--- a/apps/web/app/components/RichText/utils/uploadDroppedFiles.test.ts
+++ b/apps/web/app/components/RichText/utils/uploadDroppedFiles.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { uploadDroppedFilesAtPosition } from "./uploadDroppedFiles";
+
+import type { Editor as TiptapEditor } from "@tiptap/react";
+
+describe("uploadDroppedFilesAtPosition", () => {
+  it("advances the insertion position by the size of each inserted file node", async () => {
+    const calls: string[] = [];
+    let documentSize = 10;
+    const editor = {
+      commands: {
+        setTextSelection: vi.fn((position: number) => calls.push(`position:${position}`)),
+        focus: vi.fn(() => calls.push("focus")),
+      },
+      state: {
+        doc: {
+          content: {
+            get size() {
+              return documentSize;
+            },
+          },
+        },
+      },
+    } as unknown as TiptapEditor;
+    const files = [
+      new File(["video"], "video.mp4", { type: "video/mp4" }),
+      new File(["pdf"], "document.pdf", { type: "application/pdf" }),
+    ];
+    const onUpload = vi.fn(
+      async (
+        file?: File,
+        _editor?: TiptapEditor | null,
+        _visibility?: string,
+        position?: number,
+      ) => {
+        calls.push(`upload:${file?.name}:${position}`);
+        documentSize += file?.type === "video/mp4" ? 3 : 4;
+      },
+    );
+
+    await uploadDroppedFilesAtPosition({
+      editor,
+      files,
+      position: 7,
+      visibility: "public",
+      onUpload,
+    });
+
+    expect(editor.commands.setTextSelection).toHaveBeenNthCalledWith(1, 7);
+    expect(editor.commands.setTextSelection).toHaveBeenNthCalledWith(2, 10);
+    expect(onUpload).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual([
+      "position:7",
+      "focus",
+      "upload:video.mp4:7",
+      "position:10",
+      "focus",
+      "upload:document.pdf:10",
+      "focus",
+    ]);
+  });
+});

--- a/apps/web/app/components/RichText/utils/uploadDroppedFiles.ts
+++ b/apps/web/app/components/RichText/utils/uploadDroppedFiles.ts
@@ -1,0 +1,42 @@
+import type { EditableResourceVisibility } from "@repo/shared";
+import type { Editor as TiptapEditor } from "@tiptap/react";
+
+type UploadDroppedFilesArgs = {
+  editor: TiptapEditor | null;
+  files: File[];
+  position: number;
+  visibility: EditableResourceVisibility;
+  onUpload: (
+    file?: File,
+    editor?: TiptapEditor | null,
+    visibility?: EditableResourceVisibility,
+    position?: number,
+  ) => Promise<void>;
+};
+
+export const uploadDroppedFilesAtPosition = async ({
+  editor,
+  files,
+  position,
+  visibility,
+  onUpload,
+}: UploadDroppedFilesArgs) => {
+  let insertionPosition = position;
+
+  editor?.commands.setTextSelection(insertionPosition);
+  editor?.commands.focus();
+
+  for (const [index, file] of files.entries()) {
+    const documentSizeBeforeUpload = editor?.state.doc.content.size ?? 0;
+    await onUpload(file, editor, visibility, insertionPosition);
+
+    const documentSizeAfterUpload = editor?.state.doc.content.size ?? documentSizeBeforeUpload;
+    insertionPosition += Math.max(0, documentSizeAfterUpload - documentSizeBeforeUpload);
+
+    if (index < files.length - 1) {
+      editor?.commands.setTextSelection(insertionPosition);
+    }
+
+    editor?.commands.focus();
+  }
+};

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.test.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.test.ts
@@ -1,0 +1,47 @@
+import { ENTITY_TYPES } from "@repo/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { insertResourceIntoEditor } from "~/components/RichText/utils/insertResourceIntoEditor";
+
+import { buildRichTextFileUploadHandler } from "./buildRichTextFileUploadHandler";
+
+import type { Editor as TiptapEditor } from "@tiptap/react";
+
+vi.mock("~/components/RichText/utils/insertResourceIntoEditor", () => ({
+  insertResourceIntoEditor: vi.fn(),
+}));
+
+describe("buildRichTextFileUploadHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restores the batch position after the PDF display-mode dialog", async () => {
+    const setTextSelection = vi.fn();
+    const editor = { commands: { setTextSelection } } as unknown as TiptapEditor;
+    const askForDisplayMode = vi.fn().mockResolvedValue("preview");
+    const handler = buildRichTextFileUploadHandler({
+      entityType: ENTITY_TYPES.LESSON,
+      getVideoSessionForFile: vi.fn(),
+      uploadVideo: vi.fn(),
+      uploadResourceFile: vi.fn().mockResolvedValue("resource-id"),
+      askForDisplayMode,
+      onVideoUploadError: vi.fn(),
+      fallbackUploadErrorMessage: "Upload failed",
+    });
+
+    await handler(
+      new File(["pdf"], "document.pdf", { type: "application/pdf" }),
+      editor,
+      "public",
+      12,
+    );
+
+    expect(askForDisplayMode).toHaveBeenCalledWith("document.pdf");
+    expect(setTextSelection).toHaveBeenCalledWith(12);
+    expect(insertResourceIntoEditor).toHaveBeenCalledOnce();
+    expect(setTextSelection.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(insertResourceIntoEditor).mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
+++ b/apps/web/app/hooks/buildRichTextFileUploadHandler.ts
@@ -81,6 +81,7 @@ const handleVideoUpload = async ({
   uploadQueue,
   insertOnUpload,
   visibility,
+  insertionPosition,
 }: {
   editor?: TiptapEditor | null;
   file: File;
@@ -95,6 +96,7 @@ const handleVideoUpload = async ({
   uploadQueue?: BuildRichTextFileUploadHandlerArgs["uploadQueue"];
   insertOnUpload: boolean;
   visibility?: EditableResourceVisibility;
+  insertionPosition?: number;
 }) => {
   const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "video" });
   const uploadId = queueId ?? crypto.randomUUID();
@@ -104,6 +106,9 @@ const handleVideoUpload = async ({
   }
 
   if (insertOnUpload) {
+    if (insertionPosition !== undefined) {
+      editor?.commands.setTextSelection(insertionPosition);
+    }
     await insertPendingVideoNode({
       editor,
       file,
@@ -187,6 +192,7 @@ const handleResourceUpload = async ({
   uploadQueue,
   insertOnUpload,
   visibility,
+  insertionPosition,
 }: {
   editor?: TiptapEditor | null;
   file: File;
@@ -199,6 +205,7 @@ const handleResourceUpload = async ({
   uploadQueue?: BuildRichTextFileUploadHandlerArgs["uploadQueue"];
   insertOnUpload: boolean;
   visibility?: EditableResourceVisibility;
+  insertionPosition?: number;
 }) => {
   const queueId = uploadQueue?.enqueue({ fileName: file.name, kind: "resource" });
 
@@ -235,6 +242,9 @@ const handleResourceUpload = async ({
   }
 
   if (insertOnUpload) {
+    if (insertionPosition !== undefined) {
+      editor?.commands.setTextSelection(insertionPosition);
+    }
     await insertResourceNode({
       editor,
       resourceId,
@@ -345,6 +355,7 @@ export const buildRichTextFileUploadHandler = ({
     file?: File,
     editor?: TiptapEditor | null,
     visibility?: EditableResourceVisibility,
+    insertionPosition?: number,
   ) => {
     if (!file) return;
 
@@ -362,6 +373,7 @@ export const buildRichTextFileUploadHandler = ({
         uploadQueue,
         insertOnUpload,
         visibility,
+        insertionPosition,
       });
       return;
     }
@@ -378,6 +390,7 @@ export const buildRichTextFileUploadHandler = ({
       uploadQueue,
       insertOnUpload,
       visibility,
+      insertionPosition,
     });
   };
 };


### PR DESCRIPTION
## Issue(s)

- #1770 

## Overview

Fixes rich-text lesson uploads where dropping multiple files could insert them at the same editor position and cause one resource to replace another.

The upload flow now maintains an explicit insertion position for every file in the batch. That position advances after each inserted node and is restored immediately before insertion, including after a PDF or presentation display-mode dialog temporarily interrupts the editor selection.

The change also narrows the repository requirement for business-spec updates to meaningful product changes rather than cosmetic work, refactors, or small fixes that restore intended behavior.

## Business Value

Course creators can drag and drop mixed batches of lesson resources, such as videos and PDFs, without losing previously inserted content. This makes bulk lesson creation more reliable and avoids requiring creators to find and reinsert files that were uploaded successfully but disappeared from the lesson editor.

## Screenshots / Video


https://github.com/user-attachments/assets/4db0b87e-9851-436e-96e4-347928ef464b


