### PR TITLE
chore: open the relevant course directly from mention notifications

### DIFF
--- a/apps/api/src/course-chat/handlers/__tests__/course-chat-mention-email.handler.spec.ts
+++ b/apps/api/src/course-chat/handlers/__tests__/course-chat-mention-email.handler.spec.ts
@@ -76,6 +76,7 @@ describe("CourseChatMentionEmailHandler", () => {
           es: 'En el curso "Seguridad"',
           fr: "Dans le cours « Sécurité »",
         },
+        sourceId: courseId,
         usersToNotify: [mentionedUserId],
       }),
     );

--- a/apps/api/src/course-chat/handlers/course-chat-mention-email.handler.ts
+++ b/apps/api/src/course-chat/handlers/course-chat-mention-email.handler.ts
@@ -87,7 +87,7 @@ export class CourseChatMentionEmailHandler
         sendEmail: false,
         emailTemplate: ANNOUNCEMENT_EMAIL_TEMPLATES.DEFAULT,
         sourceType: ANNOUNCEMENT_SOURCE_TYPES.COURSE_CHAT,
-        sourceId: null,
+        sourceId: courseId,
         usersToNotify: uniqueMentionedUserIds,
       });
 

--- a/apps/web/app/modules/Notifications/components/NotificationAnnouncementItem.test.tsx
+++ b/apps/web/app/modules/Notifications/components/NotificationAnnouncementItem.test.tsx
@@ -1,0 +1,95 @@
+import { createRemixStub } from "@remix-run/testing";
+import {
+  ANNOUNCEMENT_SOURCE_TYPES,
+  ANNOUNCEMENT_STATUSES,
+  SUPPORTED_LANGUAGES,
+} from "@repo/shared";
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "~/components/ui/tooltip";
+import { renderWith } from "~/utils/testUtils";
+
+import { NotificationAnnouncementItem } from "./NotificationAnnouncementItem";
+
+import type { NotificationAnnouncement } from "../notifications.types";
+
+const markAsRead = vi.fn();
+const parentClick = vi.fn();
+
+vi.mock("~/api/mutations/useMarkAnnouncementAsRead", () => ({
+  useMarkAnnouncementAsRead: () => ({ mutate: markAsRead, isPending: false }),
+}));
+
+vi.mock("~/api/mutations/admin/useDeleteAnnouncement", () => ({
+  useDeleteAnnouncement: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+const courseId = "11111111-1111-4111-8111-111111111111";
+const announcement: NotificationAnnouncement = {
+  id: "22222222-2222-4222-8222-222222222222",
+  createdAt: "2026-09-08T08:00:00.000Z",
+  updatedAt: "2026-09-08T08:00:00.000Z",
+  authorId: "33333333-3333-4333-8333-333333333333",
+  audience: "selected_users",
+  status: ANNOUNCEMENT_STATUSES.PUBLISHED,
+  scheduledAt: null,
+  publishedAt: null,
+  sendEmail: false,
+  emailTemplate: "default",
+  sourceType: ANNOUNCEMENT_SOURCE_TYPES.COURSE_CHAT,
+  sourceId: courseId,
+  title: "You were mentioned",
+  content: 'In the course "Safety"',
+  baseLanguage: SUPPORTED_LANGUAGES.EN,
+  availableLocales: [SUPPORTED_LANGUAGES.EN],
+  deletedAt: null,
+  isRead: false,
+};
+
+const renderItem = (item: NotificationAnnouncement) => {
+  const RemixStub = createRemixStub([
+    {
+      path: "/",
+      Component: () => (
+        <TooltipProvider>
+          <div role="button" tabIndex={0} onClick={parentClick} onKeyDown={vi.fn()}>
+            <NotificationAnnouncementItem announcement={item} canDelete={false} />
+          </div>
+        </TooltipProvider>
+      ),
+    },
+    { path: "/course/:courseId", Component: () => null },
+  ]);
+
+  return renderWith().render(<RemixStub />);
+};
+
+describe("NotificationAnnouncementItem", () => {
+  beforeEach(() => {
+    markAsRead.mockClear();
+    parentClick.mockClear();
+  });
+
+  it("links the course notification without marking it read or propagating the click", () => {
+    renderItem(announcement);
+
+    const link = screen.getByRole("link", { name: /You were mentioned/i });
+    expect(link).toHaveAttribute("href", `/course/${courseId}`);
+
+    fireEvent.click(link);
+    expect(markAsRead).not.toHaveBeenCalled();
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("does not link a manual announcement", () => {
+    renderItem({
+      ...announcement,
+      sourceType: ANNOUNCEMENT_SOURCE_TYPES.MANUAL,
+      sourceId: null,
+      content: "A manual announcement",
+    });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/modules/Notifications/components/NotificationAnnouncementItem.tsx
+++ b/apps/web/app/modules/Notifications/components/NotificationAnnouncementItem.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@remix-run/react";
 import { ANNOUNCEMENT_SOURCE_TYPES, ANNOUNCEMENT_STATUSES } from "@repo/shared";
 import { formatDistanceToNow } from "date-fns";
 import { CheckCheck, Megaphone, Trash2 } from "lucide-react";
@@ -22,6 +23,7 @@ import { useLanguageStore } from "~/modules/Dashboard/Settings/Language/Language
 import { getDateLocale } from "~/utils/getDateLocale";
 
 import { NOTIFICATIONS_HANDLES } from "../handles";
+import { getNotificationHref } from "../utils";
 
 import { SafeAnnouncementContent } from "./SafeAnnouncementContent";
 
@@ -48,6 +50,8 @@ export function NotificationAnnouncementItem({
   const canDeleteAnnouncement =
     canDelete && announcement.sourceType === ANNOUNCEMENT_SOURCE_TYPES.MANUAL;
 
+  const notificationHref = getNotificationHref(announcement);
+
   const distance = formatDistanceToNow(new Date(announcement.createdAt), {
     addSuffix: true,
     locale: getDateLocale(language),
@@ -55,14 +59,8 @@ export function NotificationAnnouncementItem({
 
   const handleMarkAsRead = () => markAsRead({ id: announcement.id });
 
-  return (
-    <article
-      className={cn(
-        "group grid grid-cols-[40px_1fr_auto] gap-3 rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition-colors hover:border-primary-200 hover:bg-primary-50/40",
-        isUnread && highlightUnread && "border-primary-300 bg-primary-50/60",
-      )}
-      data-testid={NOTIFICATIONS_HANDLES.card(announcement.id)}
-    >
+  const notificationContent = (
+    <>
       <div className="grid size-10 place-items-center rounded-lg bg-primary-100 text-primary-800">
         <Megaphone className="size-5" aria-hidden />
       </div>
@@ -84,6 +82,28 @@ export function NotificationAnnouncementItem({
           <span>{distance}</span>
         </div>
       </div>
+    </>
+  );
+
+  return (
+    <article
+      className={cn(
+        "group grid grid-cols-[1fr_auto] gap-3 rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition-colors hover:border-primary-200 hover:bg-primary-50/40",
+        isUnread && highlightUnread && "border-primary-300 bg-primary-50/60",
+      )}
+      data-testid={NOTIFICATIONS_HANDLES.card(announcement.id)}
+    >
+      {notificationHref ? (
+        <Link
+          to={notificationHref}
+          className="grid min-w-0 grid-cols-[40px_1fr] gap-3 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {notificationContent}
+        </Link>
+      ) : (
+        <div className="grid min-w-0 grid-cols-[40px_1fr] gap-3">{notificationContent}</div>
+      )}
 
       <div className="flex items-start gap-1">
         {isUnread && (

--- a/apps/web/app/modules/Notifications/utils.ts
+++ b/apps/web/app/modules/Notifications/utils.ts
@@ -1,5 +1,10 @@
-import { SUPPORTED_LANGUAGES, type SupportedLanguages } from "@repo/shared";
+import {
+  ANNOUNCEMENT_SOURCE_TYPES,
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguages,
+} from "@repo/shared";
 
+import type { NotificationAnnouncement } from "./notifications.types";
 import type { TranslationDraft, TranslationFormValues } from "./types";
 
 const emptyTranslation = (): TranslationDraft => ({ title: "", content: "" });
@@ -27,3 +32,11 @@ export const getDefaultAnnouncementFormValues = (): TranslationFormValues => ({
 
 export const buildAnnouncementScheduledAt = (date: string, time: string) =>
   new Date(`${date}T${time}:00`).toISOString();
+
+export const getNotificationHref = (announcement: NotificationAnnouncement) => {
+  if (announcement.sourceType === ANNOUNCEMENT_SOURCE_TYPES.COURSE_CHAT && announcement.sourceId) {
+    return `/course/${announcement.sourceId}`;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Issue(s)

- #1861

## Overview

Adds navigation from course-chat mention notifications to the related course.

- Stores the course ID as the notification source ID when creating a mention notification.
- Resolves notification destinations through a reusable `getNotificationHref` utility.
- Makes course-chat notification content link to the originating course.
- Stops the navigation click from propagating, so opening the course does not mark the notification as read.
- Keeps manual announcements non-clickable.

## Business Value

Learners can move directly from a mention notification to the relevant course, reducing the effort required to find the discussion context. Navigating to the course does not clear the unread state, so learners can explicitly mark the notification as read after they have handled it.
