### PR TITLE
feat: let integrations update tenant environment settings

### DIFF
--- a/apps/api/src/integration/integration-tenant-api-keys.controller.spec.ts
+++ b/apps/api/src/integration/integration-tenant-api-keys.controller.spec.ts
@@ -1,0 +1,127 @@
+import { ForbiddenException, UnauthorizedException, type ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { PERMISSIONS } from "@repo/shared";
+
+import { PermissionsGuard } from "src/common/guards/permissions.guard";
+
+import { IntegrationApiKeyGuard } from "./guards/integration-api-key.guard";
+import { IntegrationController } from "./integration.controller";
+
+import type { IntegrationService } from "./integration.service";
+import type { IntegrationRequest } from "./integration.types";
+
+jest.mock("./integration.service", () => ({ IntegrationService: class {} }));
+jest.mock("src/user/user.service", () => ({ UserService: class {} }));
+jest.mock("src/group/group.service", () => ({ GroupService: class {} }));
+jest.mock("src/courses/course.service", () => ({ CourseService: class {} }));
+
+describe("IntegrationController.updateTenantApiKeys", () => {
+  const tenantId = "00000000-0000-4000-8000-000000000001";
+  const keyTenantId = "00000000-0000-4000-8000-000000000002";
+
+  function setup(headers: Record<string, string> = { "x-api-key": "test-integration-key" }) {
+    const user = {
+      userId: "00000000-0000-4000-8000-000000000003",
+      email: "operator@example.test",
+      roleSlugs: [],
+      permissions: [PERMISSIONS.INTEGRATION_API_USE, PERMISSIONS.TENANT_MANAGE],
+      tenantId: keyTenantId,
+    };
+    const authenticateApiKey = jest
+      .fn()
+      .mockResolvedValue({ user, keyId: "key-id", keyTenantId, keyTenantIsManaging: true });
+    const updateTenantApiKeysForIntegration = jest
+      .fn()
+      .mockResolvedValue({ tenantId, updatedKeys: ["LUMA_API_KEY"] });
+    const service = {
+      authenticateApiKey,
+      markKeyAsUsed: jest.fn(),
+      updateTenantApiKeysForIntegration,
+    } as unknown as IntegrationService;
+    const request = { headers } as IntegrationRequest;
+    const context = {
+      switchToHttp: () => ({ getRequest: () => request }),
+      getHandler: () => IntegrationController.prototype.updateTenantApiKeys,
+      getClass: () => IntegrationController,
+    } as unknown as ExecutionContext;
+    const reflector = new Reflector();
+    return {
+      user,
+      request,
+      context,
+      authenticateApiKey,
+      updateTenantApiKeysForIntegration,
+      guard: new IntegrationApiKeyGuard(service, reflector),
+      permissionsGuard: new PermissionsGuard(reflector),
+      controller: new IntegrationController(
+        service,
+        undefined as never,
+        undefined as never,
+        undefined as never,
+      ),
+    };
+  }
+
+  it("accepts the integration key without X-Tenant-Id and returns the response envelope", async () => {
+    const {
+      guard,
+      permissionsGuard,
+      context,
+      controller,
+      user,
+      updateTenantApiKeysForIntegration,
+    } = setup();
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(permissionsGuard.canActivate(context)).toBe(true);
+    const body = { name: "LUMA_API_KEY", value: "test-luma-key" };
+    const keyTenant = { tenantId: keyTenantId, isManaging: true };
+    await expect(controller.updateTenantApiKeys(tenantId, body, user, keyTenant)).resolves.toEqual({
+      data: { tenantId, updatedKeys: ["LUMA_API_KEY"] },
+    });
+    expect(updateTenantApiKeysForIntegration).toHaveBeenCalledWith(tenantId, body, user, keyTenant);
+  });
+
+  it("rejects a missing credential before authentication", async () => {
+    const { guard, context, authenticateApiKey } = setup({});
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(authenticateApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid credential", async () => {
+    const { guard, context, authenticateApiKey } = setup();
+    authenticateApiKey.mockRejectedValue(new UnauthorizedException());
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it("requires integration permission from the authenticated owner", async () => {
+    const { guard, permissionsGuard, context, user } = setup();
+    user.permissions = [PERMISSIONS.TENANT_MANAGE];
+    await guard.canActivate(context);
+    expect(() => permissionsGuard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it("preserves the real managing key owner when a target header is supplied", async () => {
+    const { guard, context, request } = setup({
+      "x-api-key": "test-integration-key",
+      "x-tenant-id": tenantId,
+    });
+    await guard.canActivate(context);
+    expect(request.user?.tenantId).toBe(tenantId);
+    expect(request.integrationKeyTenantId).toBe(keyTenantId);
+    expect(request.integrationKeyTenantIsManaging).toBe(true);
+  });
+
+  it("rejects a non-managing key trying to impersonate the managing tenant via a header", async () => {
+    const { guard, context, authenticateApiKey, user } = setup({
+      "x-api-key": "test-integration-key",
+      "x-tenant-id": keyTenantId,
+    });
+    authenticateApiKey.mockResolvedValue({
+      user,
+      keyId: "key-id",
+      keyTenantId: tenantId,
+      keyTenantIsManaging: false,
+    });
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/api/src/integration/integration-tenant-api-keys.spec.ts
+++ b/apps/api/src/integration/integration-tenant-api-keys.spec.ts
@@ -1,0 +1,279 @@
+import { NotFoundException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PERMISSIONS } from "@repo/shared";
+import { Value } from "@sinclair/typebox/value";
+
+import { ALLOWED_SECRETS } from "src/env/env.config";
+import { EnvService } from "src/env/services/env.service";
+import { dbAls } from "src/storage/db/db-als.store";
+
+import { IntegrationService } from "./integration.service";
+import { integrationUpdateTenantApiKeysSchema } from "./schemas/integration-tenant-api-keys.schema";
+
+import type { CurrentUserType } from "src/common/types/current-user.type";
+import type { EncryptedEnvBody } from "src/env/env.schema";
+import type { EnvRepository } from "src/env/repositories/env.repository";
+
+jest.mock("src/permissions/permissions.service", () => ({ PermissionsService: class {} }));
+jest.mock("src/super-admin/tenants.service", () => ({ TenantsService: class {} }));
+jest.mock("./integration.repository", () => ({ IntegrationRepository: class {} }));
+
+describe("Integration tenant API key updates", () => {
+  const tenantId = "00000000-0000-4000-8000-000000000001";
+  const managingTenantId = "00000000-0000-4000-8000-000000000002";
+  const apiKey = "test-only-luma-key";
+  const keyTenant = { tenantId: managingTenantId, isManaging: true };
+  const actor: CurrentUserType = {
+    userId: "00000000-0000-4000-8000-000000000003",
+    email: "operator@example.test",
+    tenantId: managingTenantId,
+    roleSlugs: [],
+    permissions: [PERMISSIONS.INTEGRATION_API_USE, PERMISSIONS.TENANT_MANAGE],
+  };
+
+  function createService() {
+    const persisted = new Map<string, EncryptedEnvBody>();
+    const getTenantById = jest.fn().mockResolvedValue({ id: tenantId });
+    const bulkUpsertEnv = jest.fn(async (envs: EncryptedEnvBody[]) => {
+      for (const env of envs) persisted.set(`${dbAls.getStore()?.tenantId}:${env.name}`, env);
+    });
+    const getEnv = jest.fn(async (name: string) => {
+      const env = persisted.get(`${dbAls.getStore()?.tenantId}:${name}`);
+      if (!env) return undefined;
+      return { ...env, encryptedDekIV: env.dekIv, encryptedDekTag: env.dekTag };
+    });
+    const publish = jest.fn().mockResolvedValue(undefined);
+    const envService = new EnvService(
+      { bulkUpsertEnv, getEnv } as unknown as EnvRepository,
+      new ConfigService(),
+      { publish } as never,
+    );
+    const runWithTenantTransaction = jest.fn((id: string, callback: () => Promise<void>) =>
+      dbAls.run({ tenantId: id }, callback),
+    );
+    const service = new IntegrationService(
+      { getTenantById } as never,
+      undefined as never,
+      undefined as never,
+      undefined as never,
+      envService,
+      { runWithTenantTransaction } as never,
+    );
+    return {
+      service,
+      envService,
+      persisted,
+      getTenantById,
+      bulkUpsertEnv,
+      publish,
+      runWithTenantTransaction,
+    };
+  }
+
+  it("encrypts only the path tenant's key and returns no secret", async () => {
+    const { service, envService, persisted, runWithTenantTransaction, publish } = createService();
+    const result = await service.updateTenantApiKeysForIntegration(
+      tenantId,
+      { name: "LUMA_API_KEY", value: apiKey },
+      actor,
+      keyTenant,
+    );
+
+    expect(runWithTenantTransaction).toHaveBeenCalledWith(tenantId, expect.any(Function));
+    expect(result).toEqual({ tenantId, updatedKeys: ["LUMA_API_KEY"] });
+    expect(persisted.has(`${managingTenantId}:LUMA_API_KEY`)).toBe(false);
+    expect(JSON.stringify([...persisted.values()])).not.toContain(apiKey);
+    await expect(dbAls.run({ tenantId }, () => envService.getEnv("LUMA_API_KEY"))).resolves.toEqual(
+      { name: "LUMA_API_KEY", value: apiKey },
+    );
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updateEnvData: { actor: { ...actor, tenantId }, updatedEnvKeys: ["LUMA_API_KEY"] },
+      }),
+    );
+    expect(JSON.stringify(publish.mock.calls)).not.toContain(apiKey);
+    expect(actor.tenantId).toBe(managingTenantId);
+  });
+
+  it("replaces the selected key without changing a different tenant's key", async () => {
+    const { service, envService } = createService();
+    await service.updateTenantApiKeysForIntegration(
+      managingTenantId,
+      { name: "LUMA_API_KEY", value: "original-key" },
+      actor,
+      keyTenant,
+    );
+    await service.updateTenantApiKeysForIntegration(
+      tenantId,
+      { name: "LUMA_API_KEY", value: apiKey },
+      actor,
+      keyTenant,
+    );
+    await service.updateTenantApiKeysForIntegration(
+      tenantId,
+      { name: "LUMA_API_KEY", value: "replacement-key" },
+      actor,
+      keyTenant,
+    );
+    await expect(dbAls.run({ tenantId }, () => envService.getEnv("LUMA_API_KEY"))).resolves.toEqual(
+      { name: "LUMA_API_KEY", value: "replacement-key" },
+    );
+    await expect(
+      dbAls.run({ tenantId: managingTenantId }, () => envService.getEnv("LUMA_API_KEY")),
+    ).resolves.toEqual({ name: "LUMA_API_KEY", value: "original-key" });
+  });
+
+  it("uses the path tenant instead of an actor tenant set by an optional header", async () => {
+    const { service, runWithTenantTransaction } = createService();
+    await service.updateTenantApiKeysForIntegration(
+      tenantId,
+      { name: "LUMA_API_KEY", value: apiKey },
+      { ...actor, tenantId: "header-tenant" },
+      keyTenant,
+    );
+    expect(runWithTenantTransaction).toHaveBeenCalledWith(tenantId, expect.any(Function));
+  });
+
+  it.each([
+    {
+      label: "missing tenant permission",
+      actor: { ...actor, permissions: [PERMISSIONS.INTEGRATION_API_USE] },
+      keyTenant,
+    },
+    { label: "non-managing key owner", actor, keyTenant: { ...keyTenant, isManaging: false } },
+  ])(
+    "rejects $label before any lookup or write",
+    async ({ actor: deniedActor, keyTenant: deniedKeyTenant }) => {
+      const { service, getTenantById, bulkUpsertEnv, runWithTenantTransaction } = createService();
+      await expect(
+        service.updateTenantApiKeysForIntegration(
+          tenantId,
+          { name: "LUMA_API_KEY", value: apiKey },
+          deniedActor,
+          deniedKeyTenant,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(getTenantById).not.toHaveBeenCalled();
+      expect(runWithTenantTransaction).not.toHaveBeenCalled();
+      expect(bulkUpsertEnv).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a nonexistent target without writing", async () => {
+    const { service, getTenantById, bulkUpsertEnv } = createService();
+    getTenantById.mockResolvedValue(undefined);
+    await expect(
+      service.updateTenantApiKeysForIntegration(
+        tenantId,
+        { name: "LUMA_API_KEY", value: apiKey },
+        actor,
+        keyTenant,
+      ),
+    ).rejects.toThrow("superAdminTenants.error.notFound");
+    expect(bulkUpsertEnv).not.toHaveBeenCalled();
+  });
+
+  it("propagates storage failure without publishing success", async () => {
+    const { service, bulkUpsertEnv, publish } = createService();
+    bulkUpsertEnv.mockRejectedValue(new Error("storage unavailable"));
+    await expect(
+      service.updateTenantApiKeysForIntegration(
+        tenantId,
+        { name: "LUMA_API_KEY", value: apiKey },
+        actor,
+        keyTenant,
+      ),
+    ).rejects.toThrow("storage unavailable");
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {},
+    { name: "LUMA_API_KEY" },
+    { value: "test-key" },
+    { name: "MASTER_KEY", value: "forbidden" },
+    { name: "UNKNOWN_ENV", value: "forbidden" },
+    { name: "LUMA_API_KEY", value: null },
+    { name: "LUMA_API_KEY", value: 12 },
+    { name: "LUMA_API_KEY", value: "a".repeat(4097) },
+    { MASTER_KEY: "forbidden" },
+    { name: "LUMA_API_KEY", value: apiKey, MASTER_KEY: "forbidden" },
+    { name: "LUMA_API_KEY", value: apiKey, tenantId },
+  ])("rejects invalid or non-allowlisted request %#", (body) => {
+    expect(Value.Check(integrationUpdateTenantApiKeysSchema, body)).toBe(false);
+  });
+
+  it("accepts a valid selected key", () => {
+    expect(
+      Value.Check(integrationUpdateTenantApiKeysSchema, { name: "LUMA_API_KEY", value: apiKey }),
+    ).toBe(true);
+  });
+
+  it.each(ALLOWED_SECRETS)("accepts supported environment %s", (name) => {
+    expect(Value.Check(integrationUpdateTenantApiKeysSchema, { name, value: "test value" })).toBe(
+      true,
+    );
+  });
+
+  it("updates a non-Luma environment without overwriting the tenant's Luma key", async () => {
+    const { service, envService, publish } = createService();
+    await service.updateTenantApiKeysForIntegration(
+      tenantId,
+      { name: "LUMA_API_KEY", value: apiKey },
+      actor,
+      keyTenant,
+    );
+    await expect(
+      service.updateTenantApiKeysForIntegration(
+        tenantId,
+        { name: "OPENAI_API_KEY", value: "openai-test-key" },
+        actor,
+        keyTenant,
+      ),
+    ).resolves.toEqual({ tenantId, updatedKeys: ["OPENAI_API_KEY"] });
+    await expect(
+      dbAls.run({ tenantId }, () => envService.getEnv("OPENAI_API_KEY")),
+    ).resolves.toEqual({ name: "OPENAI_API_KEY", value: "openai-test-key" });
+    await expect(dbAls.run({ tenantId }, () => envService.getEnv("LUMA_API_KEY"))).resolves.toEqual(
+      { name: "LUMA_API_KEY", value: apiKey },
+    );
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        updateEnvData: { actor: { ...actor, tenantId }, updatedEnvKeys: ["OPENAI_API_KEY"] },
+      }),
+    );
+    expect(JSON.stringify(publish.mock.calls)).not.toContain("openai-test-key");
+  });
+
+  it("allows empty and multiline values like the existing environment API", async () => {
+    const { service, envService } = createService();
+    for (const value of ["", "line one\nline two"]) {
+      expect(
+        Value.Check(integrationUpdateTenantApiKeysSchema, { name: "OPENAI_API_KEY", value }),
+      ).toBe(true);
+      await service.updateTenantApiKeysForIntegration(
+        tenantId,
+        { name: "OPENAI_API_KEY", value },
+        actor,
+        keyTenant,
+      );
+      await expect(
+        dbAls.run({ tenantId }, () => envService.getEnv("OPENAI_API_KEY")),
+      ).resolves.toEqual({ name: "OPENAI_API_KEY", value });
+    }
+  });
+
+  it("rejects unsupported names in the service even when schema validation is bypassed", async () => {
+    const { service, bulkUpsertEnv, publish } = createService();
+    await expect(
+      service.updateTenantApiKeysForIntegration(
+        tenantId,
+        { name: "MASTER_KEY", value: "forbidden" },
+        actor,
+        keyTenant,
+      ),
+    ).rejects.toThrow("Secret not supported");
+    expect(bulkUpsertEnv).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/integration/integration.controller.ts
+++ b/apps/api/src/integration/integration.controller.ts
@@ -48,6 +48,12 @@ import { IntegrationApiKeyGuard } from "src/integration/guards/integration-api-k
 import { IntegrationService } from "src/integration/integration.service";
 import { IntegrationKeyTenantContext } from "src/integration/integration.types";
 import {
+  integrationUpdateTenantApiKeysSchema,
+  integrationUpdateTenantApiKeysResponseSchema,
+  type IntegrationUpdateTenantApiKeysBody,
+  type IntegrationUpdateTenantApiKeysResponse,
+} from "src/integration/schemas/integration-tenant-api-keys.schema";
+import {
   integrationCreateTenantSchema,
   integrationDeleteUserResponseSchema,
   integrationMessageResponseSchema,
@@ -193,6 +199,44 @@ export class IntegrationController {
   ): Promise<BaseResponse<IntegrationTenantLifecycleResponse>> {
     return new BaseResponse(
       await this.integrationService.updateTenantForIntegration(
+        tenantId,
+        body,
+        currentUser,
+        keyTenant,
+      ),
+    );
+  }
+
+  @Patch("tenants/:tenantId/api-keys")
+  @RequirePermission(PERMISSIONS.INTEGRATION_API_USE)
+  @IntegrationTenantOptional()
+  @ApiEndpointDocs({
+    summary: "Update a tenant environment value",
+    description:
+      "Sets or replaces a supported tenant environment value by name. Uses the same supported names as the environment settings API. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint. Values are encrypted and never returned. The tenant in the path is authoritative, regardless of X-Tenant-Id.",
+    headers: [
+      {
+        ...API_HEADERS.X_TENANT_ID,
+        required: false,
+        description: "Not required; the target tenant is in the path.",
+      },
+    ],
+  })
+  @Validate({
+    request: [
+      { type: "param", name: "tenantId", schema: UUIDSchema },
+      { type: "body", schema: integrationUpdateTenantApiKeysSchema },
+    ],
+    response: baseResponse(integrationUpdateTenantApiKeysResponseSchema),
+  })
+  async updateTenantApiKeys(
+    @Param("tenantId") tenantId: UUIDType,
+    @Body() body: IntegrationUpdateTenantApiKeysBody,
+    @CurrentUser() currentUser: CurrentUserType,
+    @IntegrationKeyTenant() keyTenant: IntegrationKeyTenantContext,
+  ): Promise<BaseResponse<IntegrationUpdateTenantApiKeysResponse>> {
+    return new BaseResponse(
+      await this.integrationService.updateTenantApiKeysForIntegration(
         tenantId,
         body,
         currentUser,

--- a/apps/api/src/integration/integration.service.ts
+++ b/apps/api/src/integration/integration.service.ts
@@ -12,8 +12,10 @@ import { PERMISSIONS, TENANT_STATUSES } from "@repo/shared";
 
 import { DatabasePg } from "src/common";
 import { hasPermission } from "src/common/permissions/permission.utils";
+import { EnvService } from "src/env/services/env.service";
 import { PermissionsService } from "src/permissions/permissions.service";
 import { DB_ADMIN } from "src/storage/db/db.providers";
+import { TenantDbRunnerService } from "src/storage/db/tenant-db-runner.service";
 import { TenantsService } from "src/super-admin/tenants.service";
 
 import { IntegrationRepository } from "./integration.repository";
@@ -25,6 +27,10 @@ import type {
   IntegrationTrainingResultsQuery,
   RotateAdminKeyData,
 } from "./integration.types";
+import type {
+  IntegrationUpdateTenantApiKeysBody,
+  IntegrationUpdateTenantApiKeysResponse,
+} from "./schemas/integration-tenant-api-keys.schema";
 import type {
   IntegrationCreateTenantBody,
   IntegrationTenantLifecycleResponse,
@@ -41,6 +47,8 @@ export class IntegrationService {
     private readonly permissionsService: PermissionsService,
     private readonly tenantsService: TenantsService,
     @Inject(DB_ADMIN) private readonly dbAdmin: DatabasePg,
+    private readonly envService: EnvService,
+    private readonly tenantDbRunner: TenantDbRunnerService,
   ) {
     if (!process.env.MASTER_KEY) throw new Error("MASTER_KEY is required for integration API keys");
 
@@ -191,6 +199,27 @@ export class IntegrationService {
     this.assertCanManageTenants(actor, keyTenant);
 
     return this.tenantsService.updateTenantById(tenantId, input);
+  }
+
+  async updateTenantApiKeysForIntegration(
+    tenantId: string,
+    input: IntegrationUpdateTenantApiKeysBody,
+    actor: CurrentUserType,
+    keyTenant: IntegrationKeyTenantContext,
+  ): Promise<IntegrationUpdateTenantApiKeysResponse> {
+    this.assertCanManageTenants(actor, keyTenant);
+
+    const tenant = await this.integrationRepository.getTenantById(tenantId);
+    if (!tenant) throw new NotFoundException("superAdminTenants.error.notFound");
+
+    await this.tenantDbRunner.runWithTenantTransaction(tenantId, () =>
+      this.envService.bulkUpsertEnv([{ name: input.name, value: input.value }], {
+        ...actor,
+        tenantId,
+      }),
+    );
+
+    return { tenantId, updatedKeys: [input.name] };
   }
 
   async getTrainingResults(

--- a/apps/api/src/integration/schemas/integration-tenant-api-keys.schema.ts
+++ b/apps/api/src/integration/schemas/integration-tenant-api-keys.schema.ts
@@ -1,0 +1,32 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+import { UUIDSchema } from "src/common";
+import { ALLOWED_SECRETS } from "src/env/env.config";
+
+export const integrationTenantEnvNameSchema = Type.Union(
+  ALLOWED_SECRETS.map((name) => Type.Literal(name)),
+);
+
+export const integrationUpdateTenantApiKeysSchema = Type.Object(
+  {
+    name: integrationTenantEnvNameSchema,
+    value: Type.String({
+      maxLength: 4096,
+      writeOnly: true,
+      description: "Tenant environment value. Stored encrypted; never returned in responses.",
+    }),
+  },
+  { additionalProperties: false },
+);
+
+export const integrationUpdateTenantApiKeysResponseSchema = Type.Object({
+  tenantId: UUIDSchema,
+  updatedKeys: Type.Array(integrationTenantEnvNameSchema),
+});
+
+export type IntegrationUpdateTenantApiKeysBody = Static<
+  typeof integrationUpdateTenantApiKeysSchema
+>;
+export type IntegrationUpdateTenantApiKeysResponse = Static<
+  typeof integrationUpdateTenantApiKeysResponseSchema
+>;

--- a/apps/api/src/swagger/api-schema.json
+++ b/apps/api/src/swagger/api-schema.json
@@ -14463,6 +14463,72 @@
         ]
       }
     },
+    "/api/integration/tenants/{tenantId}/api-keys": {
+      "patch": {
+        "operationId": "IntegrationController_updateTenantApiKeys",
+        "summary": "Update a tenant environment value",
+        "description": "Sets or replaces a supported tenant environment value by name. Uses the same supported names as the environment settings API. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint. Values are encrypted and never returned. The tenant in the path is authoritative, regardless of X-Tenant-Id.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Not required; the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantApiKeysBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTenantApiKeysResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
     "/api/integration/tenants/{tenantId}/deactivate": {
       "post": {
         "operationId": "IntegrationController_deactivateTenant",
@@ -67102,6 +67168,270 @@
               "isManaging",
               "createdAt",
               "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateTenantApiKeysBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "const": "MICROSOFT_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_CALENDAR_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_CALENDAR_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "OPENAI_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_READ_ONLY_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_LIBRARY_ID",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_CDN_URL",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_TOKEN_SIGNING_KEY",
+                "type": "string"
+              },
+              {
+                "const": "GOOGLE_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "GOOGLE_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "GOOGLE_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "VITE_GOOGLE_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "VITE_MICROSOFT_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "STRIPE_WEBHOOK_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "STRIPE_SECRET_KEY",
+                "type": "string"
+              },
+              {
+                "const": "VITE_STRIPE_PUBLISHABLE_KEY",
+                "type": "string"
+              },
+              {
+                "const": "SLACK_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "SLACK_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "SLACK_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "VITE_SLACK_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "LUMA_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "LIVEKIT_URL",
+                "type": "string"
+              },
+              {
+                "const": "LIVEKIT_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "LIVEKIT_API_SECRET",
+                "type": "string"
+              }
+            ]
+          },
+          "value": {
+            "maxLength": 4096,
+            "writeOnly": true,
+            "description": "Tenant environment value. Stored encrypted; never returned in responses.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
+      "UpdateTenantApiKeysResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "tenantId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "updatedKeys": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "const": "MICROSOFT_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_CALENDAR_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_CALENDAR_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "OPENAI_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_READ_ONLY_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_LIBRARY_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_CDN_URL",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_TOKEN_SIGNING_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "GOOGLE_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "GOOGLE_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "GOOGLE_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_GOOGLE_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_MICROSOFT_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "STRIPE_WEBHOOK_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "STRIPE_SECRET_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_STRIPE_PUBLISHABLE_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "SLACK_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "SLACK_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "SLACK_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_SLACK_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LUMA_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LIVEKIT_URL",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LIVEKIT_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LIVEKIT_API_SECRET",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            "required": [
+              "tenantId",
+              "updatedKeys"
             ]
           }
         },

--- a/apps/api/src/swagger/integration-api-schema.json
+++ b/apps/api/src/swagger/integration-api-schema.json
@@ -217,6 +217,72 @@
         ]
       }
     },
+    "/api/integration/tenants/{tenantId}/api-keys": {
+      "patch": {
+        "operationId": "IntegrationController_updateTenantApiKeys",
+        "summary": "Update a tenant environment value",
+        "description": "Sets or replaces a supported tenant environment value by name. Uses the same supported names as the environment settings API. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint. Values are encrypted and never returned. The tenant in the path is authoritative, regardless of X-Tenant-Id.",
+        "parameters": [
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "description": "Integration API key used to authenticate every integration request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tenantId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "X-Tenant-Id",
+            "in": "header",
+            "description": "Not required; the target tenant is in the path.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTenantApiKeysBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateTenantApiKeysResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid integration API key."
+          },
+          "403": {
+            "description": "Authenticated integration key owner is not authorized."
+          }
+        },
+        "tags": [
+          "Integration"
+        ]
+      }
+    },
     "/api/integration/tenants/{tenantId}/deactivate": {
       "post": {
         "operationId": "IntegrationController_deactivateTenant",
@@ -1501,6 +1567,270 @@
               "isManaging",
               "createdAt",
               "updatedAt"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UpdateTenantApiKeysBody": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "const": "MICROSOFT_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_CALENDAR_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_CALENDAR_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "MICROSOFT_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "OPENAI_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_READ_ONLY_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_LIBRARY_ID",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_CDN_URL",
+                "type": "string"
+              },
+              {
+                "const": "BUNNY_STREAM_TOKEN_SIGNING_KEY",
+                "type": "string"
+              },
+              {
+                "const": "GOOGLE_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "GOOGLE_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "GOOGLE_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "VITE_GOOGLE_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "VITE_MICROSOFT_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "STRIPE_WEBHOOK_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "STRIPE_SECRET_KEY",
+                "type": "string"
+              },
+              {
+                "const": "VITE_STRIPE_PUBLISHABLE_KEY",
+                "type": "string"
+              },
+              {
+                "const": "SLACK_CLIENT_ID",
+                "type": "string"
+              },
+              {
+                "const": "SLACK_CLIENT_SECRET",
+                "type": "string"
+              },
+              {
+                "const": "SLACK_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "VITE_SLACK_OAUTH_ENABLED",
+                "type": "string"
+              },
+              {
+                "const": "LUMA_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "LIVEKIT_URL",
+                "type": "string"
+              },
+              {
+                "const": "LIVEKIT_API_KEY",
+                "type": "string"
+              },
+              {
+                "const": "LIVEKIT_API_SECRET",
+                "type": "string"
+              }
+            ]
+          },
+          "value": {
+            "maxLength": 4096,
+            "writeOnly": true,
+            "description": "Tenant environment value. Stored encrypted; never returned in responses.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ]
+      },
+      "UpdateTenantApiKeysResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "tenantId": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "updatedKeys": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "const": "MICROSOFT_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_CALENDAR_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_CALENDAR_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "MICROSOFT_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "OPENAI_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_READ_ONLY_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_LIBRARY_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_CDN_URL",
+                      "type": "string"
+                    },
+                    {
+                      "const": "BUNNY_STREAM_TOKEN_SIGNING_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "GOOGLE_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "GOOGLE_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "GOOGLE_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_GOOGLE_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_MICROSOFT_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "STRIPE_WEBHOOK_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "STRIPE_SECRET_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_STRIPE_PUBLISHABLE_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "SLACK_CLIENT_ID",
+                      "type": "string"
+                    },
+                    {
+                      "const": "SLACK_CLIENT_SECRET",
+                      "type": "string"
+                    },
+                    {
+                      "const": "SLACK_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "VITE_SLACK_OAUTH_ENABLED",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LUMA_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LIVEKIT_URL",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LIVEKIT_API_KEY",
+                      "type": "string"
+                    },
+                    {
+                      "const": "LIVEKIT_API_SECRET",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            "required": [
+              "tenantId",
+              "updatedKeys"
             ]
           }
         },

--- a/apps/web/app/api/generated-api.ts
+++ b/apps/web/app/api/generated-api.ts
@@ -9895,6 +9895,78 @@ export interface UpdateTenantResponse {
   };
 }
 
+export interface UpdateTenantApiKeysBody {
+  name:
+    | "MICROSOFT_CLIENT_ID"
+    | "MICROSOFT_CLIENT_SECRET"
+    | "MICROSOFT_CALENDAR_CLIENT_ID"
+    | "MICROSOFT_CALENDAR_CLIENT_SECRET"
+    | "MICROSOFT_OAUTH_ENABLED"
+    | "OPENAI_API_KEY"
+    | "BUNNY_STREAM_API_KEY"
+    | "BUNNY_STREAM_READ_ONLY_API_KEY"
+    | "BUNNY_STREAM_LIBRARY_ID"
+    | "BUNNY_STREAM_CDN_URL"
+    | "BUNNY_STREAM_TOKEN_SIGNING_KEY"
+    | "GOOGLE_CLIENT_ID"
+    | "GOOGLE_CLIENT_SECRET"
+    | "GOOGLE_OAUTH_ENABLED"
+    | "VITE_GOOGLE_OAUTH_ENABLED"
+    | "VITE_MICROSOFT_OAUTH_ENABLED"
+    | "STRIPE_WEBHOOK_SECRET"
+    | "STRIPE_SECRET_KEY"
+    | "VITE_STRIPE_PUBLISHABLE_KEY"
+    | "SLACK_CLIENT_ID"
+    | "SLACK_CLIENT_SECRET"
+    | "SLACK_OAUTH_ENABLED"
+    | "VITE_SLACK_OAUTH_ENABLED"
+    | "LUMA_API_KEY"
+    | "LIVEKIT_URL"
+    | "LIVEKIT_API_KEY"
+    | "LIVEKIT_API_SECRET";
+  /**
+   * Tenant environment value. Stored encrypted; never returned in responses.
+   * @maxLength 4096
+   */
+  value: string;
+}
+
+export interface UpdateTenantApiKeysResponse {
+  data: {
+    /** @format uuid */
+    tenantId: string;
+    updatedKeys: (
+      | "MICROSOFT_CLIENT_ID"
+      | "MICROSOFT_CLIENT_SECRET"
+      | "MICROSOFT_CALENDAR_CLIENT_ID"
+      | "MICROSOFT_CALENDAR_CLIENT_SECRET"
+      | "MICROSOFT_OAUTH_ENABLED"
+      | "OPENAI_API_KEY"
+      | "BUNNY_STREAM_API_KEY"
+      | "BUNNY_STREAM_READ_ONLY_API_KEY"
+      | "BUNNY_STREAM_LIBRARY_ID"
+      | "BUNNY_STREAM_CDN_URL"
+      | "BUNNY_STREAM_TOKEN_SIGNING_KEY"
+      | "GOOGLE_CLIENT_ID"
+      | "GOOGLE_CLIENT_SECRET"
+      | "GOOGLE_OAUTH_ENABLED"
+      | "VITE_GOOGLE_OAUTH_ENABLED"
+      | "VITE_MICROSOFT_OAUTH_ENABLED"
+      | "STRIPE_WEBHOOK_SECRET"
+      | "STRIPE_SECRET_KEY"
+      | "VITE_STRIPE_PUBLISHABLE_KEY"
+      | "SLACK_CLIENT_ID"
+      | "SLACK_CLIENT_SECRET"
+      | "SLACK_OAUTH_ENABLED"
+      | "VITE_SLACK_OAUTH_ENABLED"
+      | "LUMA_API_KEY"
+      | "LIVEKIT_URL"
+      | "LIVEKIT_API_KEY"
+      | "LIVEKIT_API_SECRET"
+    )[];
+  };
+}
+
 export interface DeactivateTenantResponse {
   data: {
     /** @format uuid */
@@ -18265,6 +18337,28 @@ export class API<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<void, void>({
         path: `/api/integration/tenants/${tenantId}`,
         method: "DELETE",
+        ...params,
+      }),
+
+    /**
+     * @description Sets or replaces a supported tenant environment value by name. Uses the same supported names as the environment settings API. Only integration API keys owned by a managing tenant with tenant management permission can use this endpoint. Values are encrypted and never returned. The tenant in the path is authoritative, regardless of X-Tenant-Id.
+     *
+     * @tags Integration
+     * @name IntegrationControllerUpdateTenantApiKeys
+     * @summary Update a tenant environment value
+     * @request PATCH:/api/integration/tenants/{tenantId}/api-keys
+     */
+    integrationControllerUpdateTenantApiKeys: (
+      tenantId: string,
+      data: UpdateTenantApiKeysBody,
+      params: RequestParams = {},
+    ) =>
+      this.request<UpdateTenantApiKeysResponse, void>({
+        path: `/api/integration/tenants/${tenantId}/api-keys`,
+        method: "PATCH",
+        body: data,
+        type: ContentType.Json,
+        format: "json",
         ...params,
       }),
 

--- a/docs/specs/tenant-administration-business-spec.md
+++ b/docs/specs/tenant-administration-business-spec.md
@@ -11,7 +11,7 @@ The main workflow starts in the super-admin tenant list. A managing admin browse
 ## Who Uses It
 
 - Managing platform admins browse customer tenants, use recent activity signals to identify organizations that may need attention, and permanently remove obsolete organizations when retention is no longer required.
-- Integration operators automate tenant creation, updates, deactivation, and permanent deletion from an authorized external system.
+- Integration operators automate tenant creation, updates, deactivation, and permanent deletion from an authorized external system, and update an organization's supported integration settings by name.
 - Platform operators activate or deactivate tenant workspaces.
 - Tenant admins benefit because a newly created tenant receives default global settings and an invited admin account.
 - Support staff use the tenant list as the starting point for temporary support-mode access.
@@ -25,7 +25,7 @@ The main workflow starts in the super-admin tenant list. A managing admin browse
 - Create an organization with its host, status, default settings, and invited initial admin.
 - Update organization identity, host, and active/inactive status.
 - Permanently delete another organization after confirming an irreversible warning.
-- Automate organization creation, partial updates, deactivation, and permanent deletion through the Integration API.
+- Automate organization creation, partial updates, deactivation, permanent deletion, and supported integration-setting updates through the Integration API.
 - Normalize organization hosts and prevent duplicate or invalid hosts.
 - Restrict administration to authorized users in the managing organization and prevent them from deleting their current organization.
 
@@ -45,11 +45,15 @@ When editing a tenant, the admin updates the tenant's name, host, or active/inac
 
 Access is restricted to users who have tenant-management permission and are operating from a designated managing tenant. Normal tenant users and learners are redirected away from this area.
 
+An authorized integration operator can update supported settings for an existing organization, such as its Luma, OpenAI, or LiveKit connection credentials. Luma is Mentingo's connected AI service. The operator submits the setting's name and value for the selected organization. Mentingo saves it encrypted and confirms which setting changed without returning the value. This API operation does not create provider keys or automatically provision them during tenant creation, and it adds no new UI.
+
 ## Key Technical Context
 
 - Frontend tenant pages live in `apps/web/app/modules/SuperAdmin` and are routed under `/super-admin/tenants`.
 - The tenant API lives in `apps/api/src/super-admin/tenants.controller.ts` and `apps/api/src/super-admin/tenants.service.ts`.
 - Integration lifecycle endpoints live in `apps/api/src/integration/integration.controller.ts` and reuse the tenant service's validation, update, and deletion safeguards.
+- `PATCH /api/integration/tenants/:tenantId/api-keys` accepts `{ "name": "OPENAI_API_KEY", "value": "<value>" }`. Names come from the existing `ALLOWED_SECRETS` list, not a Luma-only list. Unsupported names, extra fields, non-string values, and values over 4096 characters are rejected; empty and multiline strings are supported like the existing environment API. It requires `X-API-Key`, Integration API access, tenant-management permission, and a key owned by a managing tenant. The path determines the target; `X-Tenant-Id` is optional and cannot grant managing access. The response contains only `data.tenantId` and `data.updatedKeys`.
+- Key updates reuse the existing encrypted secret service and target-tenant transaction. The existing environment-change event records the actor and changed key names, never secret values. Other tenant secrets and global process configuration are unchanged.
 - Tenant administration requires `PERMISSIONS.TENANT_MANAGE` and `ManagingTenantAdminGuard`.
 - Hard deletion uses the tenant foreign-key cascade to remove tenant-scoped relational records atomically; the API independently rejects attempts to delete the current managing tenant.
 - Activity summaries use tenant-scoped audit records and display historical actor emails without exposing role snapshots. The five-action preview is loaded in one additional batched query for the visible organization page rather than one query per row.
@@ -61,3 +65,7 @@ Access is restricted to users who have tenant-management permission and are oper
 ## Test Evidence
 
 Frontend coverage verifies protocol-free host display with truncation and a full-value tooltip; activity-summary, five-action hover preview, trend, and active-user reach rendering; activity sort requests; status filtering; the hard-delete confirmation flow; protection of the current organization; tenant browsing; opening details; creation; updates; and denial for non-managing users. Backend E2E coverage verifies role-free latest actor snapshots, the newest-five activity limit, rolling current and previous 14-day activity summaries, distinct active-user reach, activity sorting, active/inactive filtering with matching totals, cascading tenant deletion, and rejection of current-tenant deletion. Integration API E2E coverage verifies tenant creation, partial updates, deactivation, permanent deletion, persisted update values, host normalization, current-managing-tenant protection, and rejection of lifecycle operations from non-managing tenants.
+
+Focused unit tests for the update endpoint cover the actual controller/guard metadata, missing and invalid credentials, permission checks, managing-owner/header separation, every supported environment name, empty/multiline values, unknown-name rejection at both schema and service boundaries, nonexistent tenants, key replacement, encryption/decryption, tenant-context isolation, preserving other settings, secret-free responses/events, and storage errors. Storage and transaction execution are mocked; these tests do not prove PostgreSQL RLS or transaction rollback. No live database tests or app servers are required for this focused suite.
+
+API startup generates the Integration API schema; in development it also generates the full API schema. Run `pnpm generate:client` afterward to regenerate the frontend client.


### PR DESCRIPTION
## Issue(s)

[#1895](https://github.com/Selleo/mentingo/issues/1895)

## Overview

- Add `PATCH /api/integration/tenants/:tenantId/api-keys` accepting `{ name, value }` for supported tenant environment settings, not just `LUMA_API_KEY`.
- Require managing-tenant authorization, reuse encrypted tenant-scoped storage, and return updated names without exposing values.
- Update generated API contracts and business documentation using the existing startup-based schema generation flow.
- Validation: 55 focused endpoint/service tests and 13 direct HTTP checks against the local Core API passed, including encrypted persistence, rotation, authorization, and tenant isolation. Temporary local fixtures were removed.

## Business Value

Authorized provisioning integrations can configure or rotate each organization’s connection settings without manual setup while keeping tenant secrets isolated. This delivers the Core API building block; provisioning orchestration remains separate.