### PR TITLE
feat: add scrollable voice mentor history and word highlighting to welcome messages

### DIFF
--- a/apps/api/src/audio/external-audio.service.spec.ts
+++ b/apps/api/src/audio/external-audio.service.spec.ts
@@ -19,6 +19,7 @@ import type {
   LumaSocket,
 } from "@japro/luma-sdk";
 import type { StartAudioBody } from "src/audio/types/audio.types";
+import type { ExternalAudioSession } from "src/audio/types/external-audio-session.types";
 import type { WsUser } from "src/websocket/websocket.types";
 
 jest.mock("@japro/luma-sdk", () => ({
@@ -276,6 +277,65 @@ describe("ExternalAudioService recovery", () => {
 });
 
 describe("ExternalAudioService voice markup streaming", () => {
+  it("uses the Luma welcome turn for audio, alignment, and completion", async () => {
+    const socket = { sendTTSTrigger: jest.fn() };
+    const session = {
+      sessionId: "session-1",
+      socket: socket as unknown as LumaSocket,
+      activeTurnId: null,
+      pendingTtsTrigger: false,
+      audioOutputErrors: new Map(),
+    } as ExternalAudioSession;
+    const sessionStore = new ExternalAudioSessionStore();
+    sessionStore.set(session);
+    const realtimePublisher = { emitToRoom: jest.fn() };
+    const service = new ExternalAudioService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      sessionStore,
+      {} as never,
+      realtimePublisher as never,
+    );
+    const handlers = service["createVoiceMentorSocketHandlers"](session);
+    await service.triggerTTS("session-1", { content: "Welcome" });
+    const envelope = { sessionId: "session-1", jobId: "luma-welcome-1", tsMs: 1 };
+    handlers.audioOutputAlignment({
+      ...envelope,
+      type: LUMA_MENTOR_STREAM_EVENT_TYPES.AUDIO_OUTPUT_ALIGNMENT,
+      data: { sequence: 1, words: [{ text: "Welcome", startMs: 0, endMs: 500 }] },
+    });
+    handlers.audioOutputChunk({
+      ...envelope,
+      type: LUMA_MENTOR_STREAM_EVENT_TYPES.AUDIO_OUTPUT_CHUNK,
+      data: { seq: 0, codec: "pcm_s16le", chunkBase64: "AAAA", sampleRate: 44100 },
+    });
+    for (const event of [
+      VOICE_SOCKET_EVENT.AUDIO_OUTPUT_ALIGNMENT,
+      VOICE_SOCKET_EVENT.AUDIO_SPEECH,
+    ]) {
+      expect(realtimePublisher.emitToRoom).toHaveBeenCalledWith(
+        event,
+        "session-1",
+        expect.objectContaining({ turnId: envelope.jobId }),
+      );
+    }
+    handlers.audioOutputComplete({
+      ...envelope,
+      type: LUMA_MENTOR_STREAM_EVENT_TYPES.AUDIO_OUTPUT_COMPLETE,
+      data: { totalChunks: 1 },
+    });
+    expect(realtimePublisher.emitToRoom).toHaveBeenCalledWith(
+      VOICE_SOCKET_EVENT.AUDIO_OUTPUT_COMPLETED,
+      "session-1",
+      { turnId: envelope.jobId },
+    );
+    expect(session.activeTurnId).toBeNull();
+    expect(session.pendingTtsTrigger).toBe(false);
+  });
+
   it.each(["core", "luma"])(
     "keeps raw %s speech markup separate from display events across character chunks",
     async (source) => {
@@ -306,6 +366,7 @@ describe("ExternalAudioService voice markup streaming", () => {
         recoveryRetryTimeout: null,
         clientDisconnectTimeout: null,
         activeTurnId: null,
+        pendingTtsTrigger: false,
         audioOutputErrors: new Map(),
         pendingInterruption: false,
         interruptedTurnIds: new Set(),

--- a/apps/api/src/audio/external-audio.service.ts
+++ b/apps/api/src/audio/external-audio.service.ts
@@ -16,6 +16,7 @@ import {
   type AudioOutputErrorPayload,
   type AudioOutputCompletePayload,
   type AudioOutputAlignmentPayload,
+  type AudioOutputChunkPayload,
   type AudioOutputInterruptedPayload,
   type AudioProtocolErrorPayload,
   type AudioReconnectPayload,
@@ -53,7 +54,6 @@ import { REALTIME_PUBLISHER, type RealtimePublisher } from "src/websocket/realti
 
 import type {
   AiMentorTTSPreset,
-  AudioSpeechEventPayload,
   AudioOutputAlignmentEventPayload,
   ClientSpeechBoundaryPayload,
   MentorResponseDeltaEventPayload,
@@ -83,7 +83,7 @@ type VoiceMentorSocketHandlers = {
   audioReconnectError: (payload: AudioProtocolErrorPayload) => void;
   learnerTranscription: (payload: LearnerTranscriptionPayload) => Promise<void>;
   audioOutputAlignment: (payload: AudioOutputAlignmentPayload) => void;
-  audioOutputChunk: (payload: { data: AudioSpeechEventPayload }) => void;
+  audioOutputChunk: (payload: AudioOutputChunkPayload) => void;
   audioOutputInterrupted: (payload: AudioOutputInterruptedPayload) => void;
   audioOutputError: (payload: AudioOutputErrorPayload) => void;
   audioOutputComplete: (payload: AudioOutputCompletePayload) => void;
@@ -279,7 +279,7 @@ export class ExternalAudioService {
   async triggerTTS(sessionId: string, payload: SendTTSTriggerBody) {
     const session = this.sessionStore.get(sessionId);
     if (session) {
-      session.activeTurnId = `tts-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      session.pendingTtsTrigger = true;
       session.socket.sendTTSTrigger(payload);
       return true;
     }
@@ -362,6 +362,7 @@ export class ExternalAudioService {
       recoveryRetryTimeout: null,
       clientDisconnectTimeout: null,
       activeTurnId: null,
+      pendingTtsTrigger: false,
       audioOutputErrors: new Map(),
       pendingInterruption: false,
       interruptedTurnIds: new Set(),
@@ -467,7 +468,11 @@ export class ExternalAudioService {
         );
       },
       audioOutputChunk: (payload) => {
-        if (!session.activeTurnId) {
+        if (session.pendingTtsTrigger) {
+          session.activeTurnId = payload.jobId;
+          session.pendingTtsTrigger = false;
+        }
+        if (!session.activeTurnId || payload.jobId !== session.activeTurnId) {
           return;
         }
 
@@ -476,7 +481,7 @@ export class ExternalAudioService {
           codec: payload.data.codec,
           chunkBase64: payload.data.chunkBase64,
           sampleRate: payload.data.sampleRate,
-          turnId: session.activeTurnId,
+          turnId: payload.jobId,
         };
         this.realtimePublisher.emitToRoom(
           VOICE_SOCKET_EVENT.AUDIO_SPEECH,
@@ -785,6 +790,7 @@ export class ExternalAudioService {
     const voiceDeliveryContext = this.resolveVoiceDeliveryContext(payload.data.timing);
 
     session.activeTurnId = payload.jobId ?? null;
+    session.pendingTtsTrigger = false;
     const voiceTurnWasInterrupted = session.pendingInterruption;
     session.pendingInterruption = false;
     const abortController = new AbortController();

--- a/apps/api/src/audio/types/external-audio-session.types.ts
+++ b/apps/api/src/audio/types/external-audio-session.types.ts
@@ -49,6 +49,7 @@ export type ExternalAudioSession = {
   recoveryRetryTimeout: ExternalAudioTimeout;
   clientDisconnectTimeout: ExternalAudioTimeout;
   activeTurnId: string | null;
+  pendingTtsTrigger: boolean;
   audioOutputErrors: Map<string, AudioOutputErrorData>;
   pendingInterruption: boolean;
   interruptedTurnIds: Set<string>;

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/AiMentorLesson.tsx
@@ -129,19 +129,24 @@ const AiMentorLesson = ({
   }, [currentThreadMessages, setMessages]);
 
   const appendVoiceMessage = useCallback(
-    (role: UIMessage["role"], content: string) => {
+    (role: UIMessage["role"], content: string, messageId?: string) => {
       const nextContent = content.trim();
       if (!nextContent) {
         return;
       }
 
       const nextMessage = createTextUiMessage<UIMessage>({
-        id: `voice-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+        id: messageId ?? `voice-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
         role,
         content: nextContent,
       });
 
-      setMessages((prev) => [...prev, nextMessage]);
+      setMessages((prev) => {
+        if (prev.some((message) => message.id === nextMessage.id)) {
+          return prev.map((message) => (message.id === nextMessage.id ? nextMessage : message));
+        }
+        return [...prev, nextMessage];
+      });
     },
     [setMessages],
   );
@@ -172,9 +177,9 @@ const AiMentorLesson = ({
   }, [input, lesson.threadId, sendMessage]);
 
   const handleVoiceLearnerTranscription = useCallback(
-    (text: string) => {
+    (text: string, turnId?: string) => {
       voiceResponseMessageIdRef.current = null;
-      appendVoiceMessage("user", text);
+      appendVoiceMessage(MESSAGE_ROLE.USER, text, turnId);
     },
     [appendVoiceMessage],
   );
@@ -222,7 +227,7 @@ const AiMentorLesson = ({
       voiceResponseMessageIdRef.current = null;
 
       if (!messageId) {
-        appendVoiceMessage("assistant", text);
+        appendVoiceMessage(MESSAGE_ROLE.MENTOR, text);
         return;
       }
 
@@ -269,7 +274,7 @@ const AiMentorLesson = ({
   const isLessonCompleted = lesson.lessonCompleted === true;
   const lastMessage = messages[messages.length - 1];
   const hasStreamingAssistantText =
-    lastMessage?.role === "assistant" && getUiMessageText(lastMessage).trim().length > 0;
+    lastMessage?.role === MESSAGE_ROLE.MENTOR && getUiMessageText(lastMessage).trim().length > 0;
   const showChatLoader = isProcessing && !hasStreamingAssistantText;
   const persistedEvaluation = useMemo<AiMentorEvaluation | null>(() => {
     if (!lesson.aiMentorDetails) return null;

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/LessonForm.tsx
@@ -27,7 +27,7 @@ interface LessonFormProps {
   mentorName: string;
   mentorAvatarUrl?: string | null;
   handleSubmit: () => void;
-  onLearnerTranscription?: (text: string) => void;
+  onLearnerTranscription?: (text: string, turnId?: string) => void;
   onMentorResponseDelta?: (text: string) => void;
   onMentorResponseCompleted?: (text: string) => void;
   onAudioOutputCompleted?: () => void;
@@ -113,7 +113,7 @@ export const LessonForm = ({
 
       setLatestResponse("");
       voiceModeUI.onLearnerTranscriptionReceived();
-      onLearnerTranscription?.(revision.text);
+      onLearnerTranscription?.(revision.text, revision.turnId);
     },
     onMentorResponseDelta: (text) => {
       setLatestResponse((previous) => previous + text);
@@ -374,6 +374,7 @@ export const LessonForm = ({
       </form>
 
       <VoiceMentorModeOverlay
+        messages={messages}
         open={isVoiceMentorMode}
         state={voiceModeUI.voiceModeState}
         voiceLevel={voiceLevel}

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceConversationTranscript.test.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceConversationTranscript.test.tsx
@@ -1,10 +1,18 @@
-import { LEARNER_TRANSCRIPT_STATUSES } from "@repo/shared";
-import { screen } from "@testing-library/react";
+import { LEARNER_TRANSCRIPT_STATUSES, MESSAGE_ROLE } from "@repo/shared";
+import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { renderWith } from "~/utils/testUtils";
 
 import { VoiceConversationTranscript } from "./VoiceConversationTranscript";
+
+import type { UIMessage } from "@ai-sdk/react";
+
+const message = (id: string, role: UIMessage["role"], text: string): UIMessage => ({
+  id,
+  role,
+  parts: [{ type: "text", text }],
+});
 
 vi.mock("~/api/queries", () => ({
   useCurrentUserSuspense: vi.fn(() => ({
@@ -17,6 +25,251 @@ vi.mock("~/api/queries", () => ({
 }));
 
 describe("VoiceConversationTranscript", () => {
+  it("shows recent canonical history and updates a streamed reply in place", () => {
+    const props = {
+      mentorName: "Mentor",
+      mentorSpeech: null,
+      mentorResponse: "Welcome",
+      learnerTranscript: null,
+    };
+    const history = Array.from({ length: 15 }, (_, index) =>
+      message(String(index), MESSAGE_ROLE.MENTOR, `History ${index}`),
+    );
+    const { rerender } = renderWith().render(
+      <VoiceConversationTranscript {...props} messages={history} />,
+    );
+    expect(screen.queryByText("History 2")).not.toBeInTheDocument();
+    expect(screen.getByText("History 3")).toBeInTheDocument();
+    expect(screen.queryByText("unfinished")).not.toBeInTheDocument();
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[
+          ...history,
+          message("final", MESSAGE_ROLE.USER, "Final transcript"),
+          message("reply", MESSAGE_ROLE.MENTOR, "Reply draft"),
+        ]}
+      />,
+    );
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[
+          ...history,
+          message("final", MESSAGE_ROLE.USER, "Final transcript"),
+          message("reply", MESSAGE_ROLE.MENTOR, "Complete reply"),
+        ]}
+      />,
+    );
+    expect(screen.getAllByText("Final transcript")).toHaveLength(1);
+    expect(screen.queryByText("Reply draft")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Complete reply")).toHaveLength(1);
+  });
+
+  it("replaces a partial with its final in the same element, including delayed chat updates", () => {
+    const props = { mentorName: "Mentor", mentorSpeech: null, mentorResponse: "Welcome" };
+    const history = [message("welcome", MESSAGE_ROLE.MENTOR, "Welcome")];
+    const partial = {
+      turnId: "turn-1",
+      segmentId: "partial-segment",
+      revision: 1,
+      status: LEARNER_TRANSCRIPT_STATUSES.PARTIAL,
+      text: "I would",
+    };
+    const { rerender } = renderWith().render(
+      <VoiceConversationTranscript {...props} messages={history} learnerTranscript={partial} />,
+    );
+    const element = screen.getByText("I would");
+    expect(element).not.toHaveClass("transcript-finalized-text");
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={history}
+        learnerTranscript={{
+          ...partial,
+          segmentId: "another-segment",
+          revision: 2,
+          text: "I would like",
+        }}
+      />,
+    );
+    expect(screen.getByText("I would like")).toBe(element);
+    const final = {
+      ...partial,
+      segmentId: "final-segment",
+      revision: 3,
+      status: LEARNER_TRANSCRIPT_STATUSES.FINAL,
+      text: "I would like help.",
+    };
+    rerender(
+      <VoiceConversationTranscript {...props} messages={history} learnerTranscript={final} />,
+    );
+    expect(screen.getByText(final.text)).toBe(element);
+    expect(element).toHaveClass("transcript-finalized-text");
+    const updatedHistory = [...history, message(final.turnId, MESSAGE_ROLE.USER, final.text)];
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={updatedHistory}
+        learnerTranscript={final}
+      />,
+    );
+    expect(screen.getAllByText(final.text)).toHaveLength(1);
+    expect(screen.getByText(final.text)).toBe(element);
+    fireEvent.animationEnd(element);
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[...updatedHistory, message("reply", MESSAGE_ROLE.MENTOR, "Of course.")]}
+        learnerTranscript={final}
+      />,
+    );
+    expect(element).not.toHaveClass("transcript-finalized-text");
+    expect(screen.queryByText("I would")).not.toBeInTheDocument();
+  });
+
+  it("does not animate final messages when entering voice mode", () => {
+    const { container } = renderWith().render(
+      <VoiceConversationTranscript
+        messages={[
+          message("learner", MESSAGE_ROLE.USER, "Earlier answer"),
+          message("mentor", MESSAGE_ROLE.MENTOR, "Earlier reply"),
+        ]}
+        learnerTranscript={null}
+        mentorName="Mentor"
+        mentorResponse="Earlier reply"
+        mentorSpeech={null}
+      />,
+    );
+    expect(screen.getByText("Earlier answer")).toBeInTheDocument();
+    expect(container.querySelector(".transcript-finalized-text")).toBeNull();
+  });
+
+  it("swishes a newly finalized transcript even without a partial, but not on re-entry", () => {
+    const props = { mentorName: "Mentor", mentorSpeech: null, mentorResponse: "Welcome" };
+    const transcript = {
+      turnId: "fresh-final",
+      segmentId: "segment",
+      revision: 1,
+      status: LEARNER_TRANSCRIPT_STATUSES.FINAL,
+      text: "Final answer",
+    };
+    const history = [message(transcript.turnId, MESSAGE_ROLE.USER, transcript.text)];
+    const { rerender, unmount } = renderWith().render(
+      <VoiceConversationTranscript {...props} learnerTranscript={null} messages={[]} />,
+    );
+    rerender(
+      <VoiceConversationTranscript {...props} learnerTranscript={transcript} messages={history} />,
+    );
+    const text = screen.getByText(transcript.text);
+    expect(text).toHaveClass("transcript-finalized-text");
+    fireEvent.animationEnd(text);
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        learnerTranscript={{ ...transcript, revision: 2 }}
+        messages={history}
+      />,
+    );
+    expect(text).not.toHaveClass("transcript-finalized-text");
+    unmount();
+    renderWith().render(
+      <VoiceConversationTranscript {...props} learnerTranscript={transcript} messages={history} />,
+    );
+    expect(screen.getByText(transcript.text)).not.toHaveClass("transcript-finalized-text");
+  });
+
+  it("does not resurrect a finalized turn when playback refreshes history with database IDs", () => {
+    const props = { mentorName: "Mentor", mentorSpeech: null, mentorResponse: "Of course." };
+    const transcript = {
+      turnId: "voice-turn",
+      segmentId: "segment",
+      revision: 1,
+      status: LEARNER_TRANSCRIPT_STATUSES.FINAL,
+      text: "I need help.",
+    };
+    const { rerender, container } = renderWith().render(
+      <VoiceConversationTranscript
+        {...props}
+        learnerTranscript={transcript}
+        messages={[
+          message("voice-turn", MESSAGE_ROLE.USER, transcript.text),
+          message("voice-reply", MESSAGE_ROLE.MENTOR, "Of course."),
+        ]}
+      />,
+    );
+    const savedMessages = [
+      message("database-user", MESSAGE_ROLE.USER, transcript.text),
+      message("database-mentor", MESSAGE_ROLE.MENTOR, "Of course."),
+    ];
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        learnerTranscript={transcript}
+        messages={savedMessages}
+      />,
+    );
+    expect(screen.getAllByText(transcript.text)).toHaveLength(1);
+    expect(container.querySelector(".transcript-finalized-text")).toBeNull();
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        learnerTranscript={{
+          ...transcript,
+          turnId: "next-turn",
+          status: LEARNER_TRANSCRIPT_STATUSES.PARTIAL,
+        }}
+        messages={savedMessages}
+      />,
+    );
+    expect(screen.getAllByText(transcript.text)).toHaveLength(2);
+  });
+
+  it("follows instantly, preserves manual scroll, and removes the fade at the top", () => {
+    const props = {
+      learnerTranscript: null,
+      mentorSpeech: null,
+      mentorName: "Mentor",
+      mentorResponse: "",
+    };
+    const { rerender } = renderWith().render(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[message("1", MESSAGE_ROLE.MENTOR, "Welcome")]}
+      />,
+    );
+    const viewport = screen.getByRole("region");
+    Object.defineProperties(viewport, {
+      scrollHeight: { value: 900, configurable: true },
+      clientHeight: { value: 200, configurable: true },
+    });
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[message("1", MESSAGE_ROLE.MENTOR, "Welcome back")]}
+      />,
+    );
+    expect(viewport.scrollTop).toBe(900);
+    fireEvent.scroll(viewport, { target: { scrollTop: 100 } });
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[message("1", MESSAGE_ROLE.MENTOR, "Welcome back again")]}
+      />,
+    );
+    expect(viewport.scrollTop).toBe(100);
+    fireEvent.scroll(viewport, { target: { scrollTop: 0 } });
+    expect(viewport.style.maskImage).toContain("rgba(0,0,0,1)");
+    fireEvent.scroll(viewport, { target: { scrollTop: 700 } });
+    rerender(
+      <VoiceConversationTranscript
+        {...props}
+        messages={[message("1", MESSAGE_ROLE.MENTOR, "Latest reply")]}
+      />,
+    );
+    expect(viewport.scrollTop).toBe(900);
+  });
+
   it("keeps learner messages on the left with the mentor conversation", () => {
     renderWith().render(
       <VoiceConversationTranscript
@@ -48,6 +301,29 @@ describe("VoiceConversationTranscript", () => {
 });
 
 describe("canonical mentor display with speech alignment", () => {
+  it("highlights only the current mentor reply in the recent history", () => {
+    const { container } = renderWith().render(
+      <VoiceConversationTranscript
+        messages={[
+          message("old", MESSAGE_ROLE.MENTOR, "Hello again"),
+          message("learner", MESSAGE_ROLE.USER, "Hello"),
+          message("current", MESSAGE_ROLE.MENTOR, "Hello again"),
+        ]}
+        learnerTranscript={null}
+        mentorResponse="Hello again"
+        mentorSpeech={{
+          turnId: "current",
+          sequence: 1,
+          words: [{ text: "Hello", startMs: 0, endMs: 100 }],
+          activeWordIndex: 0,
+        }}
+        mentorName="Mentor"
+      />,
+    );
+    expect(container.querySelectorAll("span.bg-primary-100")).toHaveLength(1);
+    expect(container.querySelector("span.bg-primary-100")?.textContent).toBe("Hello");
+  });
+
   it.each([
     { text: "Wynik: 0,47.\nUżyj <button>", word: "0,47", highlighted: true },
     { text: "Wynik: 0,47.", word: "zero przecinek cztery siedem", highlighted: false },

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceConversationTranscript.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceConversationTranscript.tsx
@@ -1,5 +1,5 @@
-import { LEARNER_TRANSCRIPT_STATUSES } from "@repo/shared";
-import { useMemo } from "react";
+import { getUiMessageText, LEARNER_TRANSCRIPT_STATUSES, MESSAGE_ROLE } from "@repo/shared";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useCurrentUserSuspense } from "~/api/queries";
@@ -7,6 +7,7 @@ import { Icon } from "~/components/Icon";
 import { UserAvatar } from "~/components/UserProfile/UserAvatar";
 import { cn } from "~/lib/utils";
 
+import type { UIMessage } from "@ai-sdk/react";
 import type {
   LearnerTranscriptRevision,
   MentorSpeechPresentation,
@@ -18,6 +19,14 @@ type VoiceConversationTranscriptProps = {
   mentorSpeech: MentorSpeechPresentation | null;
   mentorName: string;
   mentorAvatarUrl?: string | null;
+  messages?: UIMessage[];
+};
+
+type TranscriptMessage = {
+  id: string;
+  role: UIMessage["role"];
+  text: string;
+  learner: LearnerTranscriptRevision | null;
 };
 
 function getDisplaySegments(text: string, words: MentorSpeechPresentation["words"]) {
@@ -82,13 +91,18 @@ function MentorTimedText({ speech, text }: { speech: MentorSpeechPresentation; t
   );
 }
 
-export function VoiceConversationTranscript({
+function TranscriptMessages({
   learnerTranscript,
   mentorResponse,
   mentorSpeech,
   mentorName,
   mentorAvatarUrl,
-}: VoiceConversationTranscriptProps) {
+  animateFinalization = false,
+  onFinalizationEnd,
+}: VoiceConversationTranscriptProps & {
+  animateFinalization?: boolean;
+  onFinalizationEnd?: () => void;
+}) {
   const { t } = useTranslation();
   const { data: currentUser } = useCurrentUserSuspense();
   const isLearnerPartial = learnerTranscript?.status === LEARNER_TRANSCRIPT_STATUSES.PARTIAL;
@@ -102,7 +116,7 @@ export function VoiceConversationTranscript({
   }
 
   return (
-    <div className="mx-auto flex min-h-24 w-full max-w-3xl flex-col justify-end gap-3">
+    <div className="mx-auto flex w-full max-w-3xl flex-col justify-end gap-3">
       {learnerTranscript && (
         <div className="flex max-w-[88%] self-start items-start gap-3">
           <div className="mt-0.5 shrink-0">
@@ -125,7 +139,12 @@ export function VoiceConversationTranscript({
                 },
               )}
             >
-              <span className={cn(!isLearnerPartial && "transcript-finalized-text")}>
+              <span
+                className={cn(
+                  animateFinalization && !isLearnerPartial && "transcript-finalized-text",
+                )}
+                onAnimationEnd={onFinalizationEnd}
+              >
                 {learnerTranscript.text}
               </span>
             </div>
@@ -153,6 +172,151 @@ export function VoiceConversationTranscript({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+export function VoiceConversationTranscript(props: VoiceConversationTranscriptProps) {
+  const { messages, mentorResponse, learnerTranscript } = props;
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const followRef = useRef(true);
+  const previousScrollTopRef = useRef(0);
+  const committedLearnerTurnsRef = useRef(new Set<string>());
+  const previousTranscriptRef = useRef(learnerTranscript);
+  const [finalizingTurnId, setFinalizingTurnId] = useState<string | null>(null);
+  const [fade, setFade] = useState(0);
+  useLayoutEffect(() => {
+    const previous = previousTranscriptRef.current;
+    previousTranscriptRef.current = learnerTranscript;
+    if (
+      learnerTranscript?.status === LEARNER_TRANSCRIPT_STATUSES.FINAL &&
+      (previous?.turnId !== learnerTranscript.turnId ||
+        previous.status !== LEARNER_TRANSCRIPT_STATUSES.FINAL) &&
+      !committedLearnerTurnsRef.current.has(learnerTranscript.turnId)
+    ) {
+      setFinalizingTurnId(learnerTranscript.turnId);
+    }
+  }, [learnerTranscript]);
+  const recentMessages = useMemo(() => {
+    if (!messages) return undefined;
+    const result: TranscriptMessage[] = messages
+      .filter(
+        (message) => message.role === MESSAGE_ROLE.USER || message.role === MESSAGE_ROLE.MENTOR,
+      )
+      .map((message) => ({
+        id: message.id,
+        role: message.role,
+        text: getUiMessageText(message),
+        learner:
+          message.role === MESSAGE_ROLE.USER
+            ? {
+                turnId: message.id,
+                segmentId: message.id,
+                revision: 0,
+                status: LEARNER_TRANSCRIPT_STATUSES.FINAL,
+                text: getUiMessageText(message),
+              }
+            : null,
+      }))
+      .filter((message) => message.text.trim());
+    if (
+      learnerTranscript?.text.trim() &&
+      !committedLearnerTurnsRef.current.has(learnerTranscript.turnId) &&
+      !result.some((message) => message.id === learnerTranscript.turnId)
+    ) {
+      result.push({
+        id: learnerTranscript.turnId,
+        role: MESSAGE_ROLE.USER,
+        text: learnerTranscript.text,
+        learner: learnerTranscript,
+      });
+    }
+    return result.slice(-12);
+  }, [messages, learnerTranscript]);
+  useLayoutEffect(() => {
+    if (
+      learnerTranscript?.status === LEARNER_TRANSCRIPT_STATUSES.FINAL &&
+      messages?.some(
+        (message) => message.role === MESSAGE_ROLE.USER && message.id === learnerTranscript.turnId,
+      )
+    ) {
+      committedLearnerTurnsRef.current.add(learnerTranscript.turnId);
+    }
+  }, [messages, learnerTranscript]);
+  const measureScroll = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    previousScrollTopRef.current = viewport.scrollTop;
+    setFade(Math.min(Math.max(viewport.scrollTop, 0) / 24, 1));
+  }, []);
+  const followLatest = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (viewport && followRef.current) {
+      viewport.scrollTop = viewport.scrollHeight;
+    }
+    measureScroll();
+  }, [measureScroll]);
+
+  useLayoutEffect(followLatest, [
+    recentMessages,
+    mentorResponse,
+    props.learnerTranscript,
+    followLatest,
+  ]);
+  useLayoutEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(followLatest);
+    if (viewportRef.current) observer.observe(viewportRef.current);
+    if (contentRef.current) observer.observe(contentRef.current);
+    return () => observer.disconnect();
+  }, [followLatest]);
+
+  return (
+    <div
+      ref={viewportRef}
+      role="region"
+      aria-label={props.mentorName}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- The scroll viewport must support keyboard navigation.
+      tabIndex={0}
+      onScroll={(event) => {
+        const viewport = event.currentTarget;
+        if (viewport.scrollTop < previousScrollTopRef.current) followRef.current = false;
+        if (viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 8) {
+          followRef.current = true;
+        }
+        measureScroll();
+      }}
+      className="mx-auto min-h-24 max-h-[clamp(8rem,28dvh,18rem)] w-full max-w-3xl shrink-0 overflow-y-auto overscroll-contain scroll-auto rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-400"
+      style={{ maskImage: `linear-gradient(to bottom, rgba(0,0,0,${1 - fade}), black 24px)` }}
+    >
+      <div ref={contentRef} className="flex flex-col gap-3 px-1 py-1">
+        {recentMessages ? (
+          recentMessages.map((message, index) => (
+            <TranscriptMessages
+              key={message.id}
+              {...props}
+              animateFinalization={message.id === finalizingTurnId}
+              onFinalizationEnd={() => setFinalizingTurnId(null)}
+              learnerTranscript={message.learner}
+              mentorResponse={message.role === MESSAGE_ROLE.MENTOR ? message.text : ""}
+              mentorSpeech={
+                index === recentMessages.length - 1 && message.text.trim() === mentorResponse.trim()
+                  ? props.mentorSpeech
+                  : null
+              }
+            />
+          ))
+        ) : (
+          <TranscriptMessages
+            {...props}
+            animateFinalization={Boolean(
+              finalizingTurnId && finalizingTurnId === learnerTranscript?.turnId,
+            )}
+            onFinalizationEnd={() => setFinalizingTurnId(null)}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceMentorModeOverlay.tsx
+++ b/apps/web/app/modules/Courses/Lesson/AiMentorLesson/components/VoiceMentorModeOverlay.tsx
@@ -18,6 +18,7 @@ import { LEARNING_HANDLES } from "../../../../../../e2e/data/learning/handles";
 
 import { VoiceConversationTranscript } from "./VoiceConversationTranscript";
 
+import type { UIMessage } from "@ai-sdk/react";
 import type {
   LearnerTranscriptRevision,
   MentorSpeechPresentation,
@@ -40,6 +41,7 @@ type VoiceMentorModeOverlayProps = {
   mentorSpeech: MentorSpeechPresentation | null;
   mentorName: string;
   mentorAvatarUrl?: string | null;
+  messages?: UIMessage[];
   hasTaskDescription: boolean;
   taskDescription: string;
   onJudge: () => void;
@@ -62,6 +64,7 @@ export function VoiceMentorModeOverlay({
   mentorSpeech,
   mentorName,
   mentorAvatarUrl,
+  messages,
   hasTaskDescription,
   taskDescription,
   onJudge,
@@ -265,6 +268,7 @@ export function VoiceMentorModeOverlay({
                 </div>
 
                 <VoiceConversationTranscript
+                  messages={messages}
                   learnerTranscript={learnerTranscript}
                   mentorResponse={response}
                   mentorSpeech={mentorSpeech}

--- a/docs/specs/ai-mentor-lessons-business-spec.md
+++ b/docs/specs/ai-mentor-lessons-business-spec.md
@@ -36,6 +36,7 @@ AI-assisted authoring prepares reviewable Mentor behavior and completion-conditi
 - Mark the lesson complete when the check passes and show a retake path afterward.
 - Show AI mentor result rows and read-only conversation previews in course statistics.
 - Support microphone entry and voice mentor actions when the relevant voice configuration is available.
+- Review the latest 12 conversation messages in voice mode, including earlier chat messages on entry, in a compact scroll area below the mentor orb.
 
 ## End-User Value
 
@@ -123,6 +124,8 @@ During voice mode, the learner's assistant message is updated as the model produ
   -- Practice creation publishes a durable outbox event. A dedicated BullMQ worker creates the structured Roleplay configuration through the shared AI Mentor configuration generator, derives the Judge from that configuration, creates the thread and welcome message, and marks the session ready or failed.
 
 ## Test Evidence
+
+Voice transcript tests verify the recent-message limit, replacement of streamed replies in place, and karaoke highlighting only on the current mentor reply. Live learner partials update one temporary message; the final transcript replaces that same message using the voice turn identity, including when the chat update arrives later. The finalization effect runs once when a new final transcript arrives, including when no partial was displayed, and never on existing messages when entering voice mode. Scrolling follows new messages instantly, pauses when the learner scrolls back, and resumes at the bottom. A soft top fade appears only where older content is above the viewport. Browser preview checks at desktop and mobile sizes verify that the capped transcript stays below the orb; these checks use sample messages, not live provider audio.
 
 Shared protocol fixtures verify complete and incremental display decoding at every chunk split, including escaped delimiters, malformed and unfinished spans, Unicode, and literal HTML. Voice streaming tests verify raw protocol forwarding and display-only deltas/completion for Core and Luma model routes. Transcript component tests ensure alignment cannot replace canonical display text with spoken wording or remove punctuation and unfinished HTML examples.
 


### PR DESCRIPTION
## Issue(s)
[#1969](https://github.com/Selleo/mentingo/issues/1969).

## Overview
- Show the latest 12 conversation messages in a capped scroll area below the Voice Mentor orb, with instant auto-follow, manual scroll preservation, and a top fade only when older content is out of view.
- Replace live learner partials with their final transcript in the same message. Prevent finalized turns from reappearing after history refreshes with database IDs.
- Run the swish once on transcript finalization, including when no partial was displayed, without replaying it when entering voice mode.
- Fix welcome-message karaoke by sharing Luma's turn identity across audio chunks, word timings, and completion. No Luma changes are required.

Validation: 19 focused web tests and 4 API audio regression tests passed; API/web type checks and targeted lint passed. Commit hooks also passed type, lint, and formatting checks. Desktop and mobile browser previews verified scrolling, fading, and separation from the orb. Live provider audio was not tested.

## Business Value
Learners can review recent conversation context while speaking, follow the welcome message with synchronized highlighting, and see their speech finalized without duplicate messages or distracting replayed effects.
